### PR TITLE
fix(tn-writer): use ellipsis not 'and' for discontinuous ATs

### DIFF
--- a/.claude/skills/tn-writer/SKILL.md
+++ b/.claude/skills/tn-writer/SKILL.md
@@ -115,7 +115,8 @@ As you work through items, keep a mental map of interpretive commitments you hav
    - For restructuring issue types (figs-infostructure, grammar-connect-logic-goal, grammar-connect-logic-result, grammar-connect-condition-fact): if the note suggests reordering parts of the verse, ensure the gl_quote spans the full area being restructured. The AT must show the complete restructured text, not just a fragment.
    - For figs-parallelism: ensure the gl_quote captures both full parallel phrases, not just the key parallel terms. Check whether the parallelism involves ellipsis (words omitted in one phrase that are understood from the other) — if so, a separate figs-ellipsis note may be needed.
    - For figs-ellipsis: the AT must supply the actual missing words from context, even if they come from a prior verse. If v23 omits a subject stated in v22, the AT must include that subject so the result is a complete, standalone clause.
-   - Connecting words in ATs: If the gl_quote includes words like "and," "but," "to," "in," "from," ensure these appear in the AT. Do not silently drop conjunctions or prepositions that are part of the quoted text.
+   - Connecting words in ATs: If the gl_quote is a **contiguous** span and includes words like "and," "but," "to," "in," "from," ensure these appear in the AT. Do not silently drop conjunctions or prepositions that are part of the quoted text.
+   - Discontinuous gl_quotes: If the gl_quote contains `…` (the English quote spans non-adjacent parts of the ULT), the AT must also use `…` between the parts — `[first part … second part]`. Never use "and" to join non-adjacent AT fragments.
 
 6. For items with `tcm_mode: true`:
    - Present multiple interpretations using the "This could mean:" format

--- a/.claude/skills/tn-writer/reference/note-style-guide.md
+++ b/.claude/skills/tn-writer/reference/note-style-guide.md
@@ -43,7 +43,8 @@ Generate an alternate translation when the matched templates contain "Alternate 
 An alternate translation should be a seamless replacement for the text in which the translation issue occurs. If you remove the GLQuote from the ULT verse and replace it with the AT, it should read correctly as natural English.
 
 ### Conjunction and Preposition Handling
-Hebrew prefixes (waw = "and", bet = "in", lamed = "to", mem = "from") are attached
+This rule applies only when the gl_quote is a **contiguous** span of text. Hebrew
+prefixes (waw = "and", bet = "in", lamed = "to", mem = "from") are attached
 to the Hebrew word but correspond to separate English words. When a gl_quote boundary
 does not include an adjacent conjunction or preposition in the ULT, your AT must
 account for this:
@@ -54,6 +55,9 @@ account for this:
   "And": [And he traveled] not just [he traveled]
 - If the ULT reads "the one causing his neighbor to drink" for a Hebrew participle,
   the AT must keep "the one": [the one overpowering his neighbor] not just [overpowering his neighbor]
+
+**Do not apply this rule to discontinuous quotes.** If the gl_quote contains `…`, the
+AT must use `…` between parts — not "and". See "Discontinuous ATs" below.
 
 ### Capitalization in ATs
 Match the sentence position of the gl_quote:
@@ -85,6 +89,17 @@ Do not include punctuation at the start or end of the AT brackets unless the not
 
 ### Discontinuous ATs
 When an AT covers non-adjacent text, use a single pair of brackets with a true ellipsis character between the parts: `[I desire peace … they desire war]` (spaces around the ellipsis).
+
+The trigger is whether the **English gl_quote** spans non-adjacent ULT text (contains `…`), regardless of whether the Hebrew OrigQuote uses `&`. Four scenarios:
+
+| gl_quote | AT |
+|---|---|
+| Contiguous (no `…`) | Normal replacement — no ellipsis needed |
+| Contiguous (no `…`), Hebrew has `&` | AT is still a normal replacement — no ellipsis |
+| Discontinuous (`…`), Hebrew has `&` | AT **must** use `…` between the parts |
+| Discontinuous (`…`), Hebrew is one span | AT **must** use `…` between the parts |
+
+Never use "and" to join non-adjacent AT fragments.
 
 ### Restructuring Notes
 For issue types that suggest reordering text (figs-infostructure, grammar-connect-logic-goal, grammar-connect-logic-result, grammar-connect-condition-fact, or any note suggesting putting one part of the verse before another), the gl_quote must cover the **entire area** being restructured, and the AT must show the full restructured result. For example, if the note says "put the second half of the verse before the first half," the gl_quote should be approximately the whole verse and the AT should be the whole verse reordered. Do not quote only one fragment of a reordering — the reader needs to see both the original order and the proposed new order.


### PR DESCRIPTION
## Summary
- Scopes the conjunction-handling rule to contiguous gl_quotes only
- Adds explicit rule: if gl_quote contains `…`, the AT must use `…` between parts — never "and"
- Adds 4-scenario table in `note-style-guide.md` clarifying when ellipsis is required

Closes #1

## Test plan
- [ ] Notes with discontinuous gl_quotes produce `[first … second]` AT format
- [ ] Notes with contiguous gl_quotes still retain leading conjunctions/prepositions

🤖 Generated with [Claude Code](https://claude.com/claude-code)