### PR TITLE
fix: correct ISA 49 number agreement decisions

### DIFF
--- a/data/quick-ref/ult_decisions.csv
+++ b/data/quick-ref/ult_decisions.csv
@@ -396,3 +396,6 @@ H5337,נָצַל,deliver,ALL,ISA 47:14 - Hiphil - deliver souls from flame,Proje
 H0376,אִישׁ,a man,ALL,ISA 47:15 - A man will wander to his side,"Use 'a man' (indefinite) not 'each' for אִישׁ in distributive contexts. Editor preference. ISA 47:15.",2026-04-20,human
 H1869,דָּרַךְ (Hiphil),making [X] tread,ALL,ISA 48:17 - the one making you tread in the way,"Show Hiphil causative explicitly; use root 'tread' which resonates throughout Isaiah. Not 'leading'. Editor ISA 48:17.",2026-04-20,human
 H6440,פָּנִים,to [X] face,ALL,ISA 48:19 - destroyed from to my face,"Render לְפָנַי as 'to my face' (not 'before my face' which is double translation). Keep preposition preceding. Editor ISA 48:19.",2026-04-20,human
+H3427,יָשַׁב,dweller,ALL,ISA 49:19 - singular participle מִיּוֹשֵׁב,"Use singular agent noun. Prefer 'dweller' over 'inhabitant' for יֹשֵׁב here; not plural 'inhabitants'.",2026-04-21,human
+H7923,שִׁכֻּלִים,bereavements,ALL,ISA 49:20 - sons of your bereavements,"Hebrew is plural; render 'bereavements' not singular 'bereavement'.",2026-04-21,human
+H7628a,שְׁבִי,captive,ALL,"ISA 49:24-25 - singular noun in captive/captive of a warrior","Use singular 'captive' in both verses, not plural 'captives'.",2026-04-21,human


### PR DESCRIPTION
Closes #7. Adds human-authoritative ULT quick-reference decisions for Isaiah 49 so generation uses singular 'dweller'/'captive' where the Hebrew is singular and plural 'bereavements' where the Hebrew is plural. Ready for review before merge.