### PR TITLE
fix: ULT draft ISA 49:5 'to be a servant' should be 'as a servant'

### DIFF
--- a/.claude/skills/ULT-gen/SKILL.md
+++ b/.claude/skills/ULT-gen/SKILL.md
@@ -129,6 +129,7 @@ Consult `reference/literalness_patterns.md` for these patterns:
 - **Hiphil causatives**: Use "made [verb]" ("made see" not "showed")
 - **Construct chains**: Keep "X of Y" ("city of fortification")
 - **Verbal idioms**: Preserve noun ("do valor" not "do valiantly")
+- **לְ + role/status noun**: Keep the prepositional phrase ("as a servant"), not an infinitive ("to be a servant")
 
 #### E. Verb Forms
 
@@ -314,6 +315,7 @@ Hebrew vocatives at clause end should stay there:
 | מִן + שָׂגַב | separation | "away from" | "from" |
 | עַל | governing | "over" | "on" |
 | לְ + infinitive | purpose | "to [verb]" | - |
+| לְ + noun (role/status) | role/resulting status | "as a/an [noun]" | "to be a/an [noun]" |
 
 ### Step 6: Format as USFM
 
@@ -439,6 +441,7 @@ Before finalizing ULT output, verify:
 - [ ] Psalm superscriptions use "chief musician" and periods between elements
 - [ ] Superscription placement matches Hebrew anchoring (`\v 1`-embedded vs standalone `\d`)
 - [ ] Comparatives with מִן use "-er than" form ("higher than I")
+- [ ] לְ + role/status nouns stay prepositional ("as a servant"), not infinitival ("to be a servant")
 - [ ] Selah uses `\qs Selah \qs*` format on its own line (space after Selah before closing tag)
 - [ ] Emphatic doubling preserved without adding words ("day, day" not "day {by} day")
 

--- a/.claude/skills/ULT-gen/reference/literalness_patterns.md
+++ b/.claude/skills/ULT-gen/reference/literalness_patterns.md
@@ -64,6 +64,15 @@ Comparatives with מִן use English comparative form:
 | gadol mimmenni | "greater than I" | "great from me" |
 | X + min (comparative) | "X-er than Y" | "X away from Y" |
 
+## Role/Status Prepositions
+
+When לְ marks a role, office, or resulting status before a noun, preserve it as a prepositional phrase rather than converting it into an infinitive:
+
+| Hebrew Pattern | Literal ULT | NOT |
+|----------------|-------------|-----|
+| לְ + role noun | "as a/an [role]" | "to be a/an [role]" |
+| יֹצְרִי מִבֶּטֶן לְעֶבֶד לוֹ | "formed me from the womb as his servant" | "formed me from the womb to be his servant" |
+
 ## Emphatic Doubling
 
 Preserve Hebrew doubling without adding words:

--- a/.claude/skills/utilities/prompts/gemini-review/ult.md
+++ b/.claude/skills/utilities/prompts/gemini-review/ult.md
@@ -7,11 +7,12 @@ Check for these specific issues:
 1. **Hebrew word order**: Where Hebrew has a marked word order (verb-subject vs English subject-verb), does the ULT preserve it when literalness requires it? Flag cases where natural English word order was used but the Hebrew structure is meaningful.
 2. **Hiphil causatives**: Hebrew Hiphil verbs should be rendered as causatives ("caused to X", "made X"). Flag cases where the causative sense is lost.
 3. **Construct chains**: Hebrew construct chains (X of Y) should use "of" rather than adjective forms. "mountain of holiness" not "holy mountain" (unless the Hebrew is actually an adjective).
-4. **Wayyiqtol connectors**: Sequential narrative verbs should use "And" or "Then" connectors, not be rendered as independent sentences.
-5. **Bracket usage**: Words in {curly braces} should only be added words not present in the Hebrew. Flag cases where a bracketed word actually translates a Hebrew element (like a prefix preposition).
-6. **Divine names**: Yahweh should be rendered as "Yahweh" (not LORD, God, etc. unless the Hebrew actually says Elohim/Adonai).
-7. **USFM formatting**: Verify proper \v, \q1, \q2 markers for poetry. Check that verse numbers are sequential and none are missing.
-8. **Natural English**: Despite being literal, the text should still be grammatical English. Flag truly broken sentences (not just unusual word order that preserves Hebrew structure).
+4. **Role/status prepositions**: When לְ marks a role or status before a noun, the ULT should preserve that as a prepositional phrase such as "as a servant," not convert it to an infinitive such as "to be a servant."
+5. **Wayyiqtol connectors**: Sequential narrative verbs should use "And" or "Then" connectors, not be rendered as independent sentences.
+6. **Bracket usage**: Words in {curly braces} should only be added words not present in the Hebrew. Flag cases where a bracketed word actually translates a Hebrew element (like a prefix preposition).
+7. **Divine names**: Yahweh should be rendered as "Yahweh" (not LORD, God, etc. unless the Hebrew actually says Elohim/Adonai).
+8. **USFM formatting**: Verify proper \v, \q1, \q2 markers for poetry. Check that verse numbers are sequential and none are missing.
+9. **Natural English**: Despite being literal, the text should still be grammatical English. Flag truly broken sentences (not just unusual word order that preserves Hebrew structure).
 
 Do NOT check:
 - Theological interpretation (that is not your domain)

--- a/data/quick-ref/ult_decisions.csv
+++ b/data/quick-ref/ult_decisions.csv
@@ -399,3 +399,8 @@ H6440,פָּנִים,to [X] face,ALL,ISA 48:19 - destroyed from to my face,"Rend
 H3427,יָשַׁב,dweller,ALL,ISA 49:19 - singular participle מִיּוֹשֵׁב,"Use singular agent noun. Prefer 'dweller' over 'inhabitant' for יֹשֵׁב here; not plural 'inhabitants'.",2026-04-21,human
 H7923,שִׁכֻּלִים,bereavements,ALL,ISA 49:20 - sons of your bereavements,"Hebrew is plural; render 'bereavements' not singular 'bereavement'.",2026-04-21,human
 H7628a,שְׁבִי,captive,ALL,"ISA 49:24-25 - singular noun in captive/captive of a warrior","Use singular 'captive' in both verses, not plural 'captives'.",2026-04-21,human
+H4147,מוֹסֵר,bonds,ALL,ISA 52:2 - bonds of your neck; dominant rendering 23.5%,"Published ISA 52 uses 'chains'; 'bonds' is dominant in index (PSA 2, 107, 116)",2026-04-21,AI
+H4893a,מִשְׁחָת,disfigured,ALL,ISA 52:14 - disfigured beyond a man; published ULT also uses disfigured,,2026-04-21,AI
+H5137b,נָזָה,sprinkle,ALL,ISA 52:15 - he will sprinkle many nations; Hiphil 3ms,Hiphil of nazah = sprinkle (cultic usage in LEV); published ISA 52 also uses 'sprinkle',2026-04-21,AI
+H2649,חִפָּזוֹן,haste,ALL,ISA 52:12 - not go out in haste; dominant rendering 28.6%,"Published ISA 52 uses 'rush'; 'haste' is dominant in index (EXO 12:11, DEU 16:3)",2026-04-21,AI
+H7919a,שָׂכַל,act wisely,ALL,ISA 52:13 - my servant will act wisely; Hiphil 3ms,Published ISA 52 and PSA 2:10 both use 'act wisely' for Hiphil; EXO 1:10 also uses 'act wisely',2026-04-21,AI


### PR DESCRIPTION
Closes #9. Add explicit ULT generation and review guidance for לְ + role/status nouns so servant-role constructions stay prepositional (for example, 'as his servant') instead of being rewritten as infinitives. Ready for review before merge.