### PR TITLE
fix: ULT ISA 49:12 renders אַפַּיִם as nostrils

### DIFF
--- a/.claude/skills/ULT-gen/SKILL.md
+++ b/.claude/skills/ULT-gen/SKILL.md
@@ -121,6 +121,8 @@ ULT keeps Hebrew idioms in their literal form. Do not substitute English equival
 
 Body-part idioms especially must stay literal - this is where Hebrew differs most from English and where translation notes will explain the meaning.
 
+For אַף / אַפַּיִם (H0639), keep the body-part sense: singular אַף = "nose"; dual אַפַּיִם = "nostrils." Do not confuse this root with face/faces language.
+
 #### D. Literalness Patterns
 
 Consult `reference/literalness_patterns.md` for these patterns:

--- a/data/glossary/project_glossary.md
+++ b/data/glossary/project_glossary.md
@@ -25,7 +25,7 @@ Editorial decisions from human review. Check this AFTER Issues Resolved, BEFORE 
 | עָנָו | H6035 | poor | afflicted | adjective, not passive participle; editor PSA 69:32; same as H6041 |
 | בּוּשׁ | H0954 | have shame | be ashamed | per issues_resolved Feb 18: focus on standing in honor/shame culture, not subjective feeling. Not passive "be ashamed." PSA 69:6, 70:2. Note: PSA 71 editor uses "put to shame" (passive) -- may reflect different editorial pass |
 | שֵׁכָר | H7941 | beer | strong drink | editor PSA 69:12 |
-| אַף | H0639 | nose | anger | preserve body-part idiom literally; editor PSA 69:24 |
+| אַף / אַפַּיִם | H0639 | nose / nostrils | anger / faces | preserve body-part idiom literally; dual אַפַּיִם = "nostrils," not "faces"; editor PSA 69:24, ISA 49:12 |
 | מָחָה | H4229a | wiped | blotted out | editor PSA 69:28; no "out" |
 | שָׁטַף | H7857 | overflow | sweep away | editor PSA 69:2,15 |
 | רַע (noun) | H7451c | hurt | harm | as noun for enemy intent; editor PSA 71:13,24 |

--- a/data/quick-ref/ult_decisions.csv
+++ b/data/quick-ref/ult_decisions.csv
@@ -4,7 +4,7 @@ H6041,עָנִי,poor,ALL,69:29 poor and in pain,"Form-based: adjective, not pas
 H6035,עָנָו,poor,ALL,69:32 The poor will see,"Form-based: adjective, not passive participle. Same as H6041.",2025-02-10,AI
 H0954,בּוּשׁ,have shame,ALL,69:6 may...not have shame; 70:2 have shame,Per issues_resolved Feb 18: focus on standing not feeling. Not 'be ashamed' or 'feel shame'.,2025-02-10,human
 H7941,שֵׁכָר,beer,ALL,69:12 drinkers of beer,Not 'strong drink'. More specific.,2025-02-10,AI
-H0639,אַף,nose,ALL,body-part idiom for anger (nose/nostrils flare; orig. context PSA 69:24),Preserve body-part idiom. Not 'anger'. Consistent with literal ULT philosophy.,2025-02-10,AI
+H0639,אַף / אַפַּיִם,nose / nostrils,ALL,"body-part idiom and lexical body-part sense; singular אַף = ""nose"", dual אַפַּיִם = ""nostrils"" (e.g. ISA 49:12)","Preserve the body-part rendering literally. Not ""anger"" and never ""face/faces"".",2026-04-21,human
 H4229a,מָחָה,wiped,ALL,69:28 wiped from the book,Not 'blotted out'. No additional preposition.,2025-02-10,AI
 H7857,שָׁטַף,overflow,ALL,"69:2,15 a flood overflows me",Not 'sweep away'. Present tense preferred.,2025-02-10,AI
 H7574,רֶתֶם,broom trees,ALL,120:4 coals of broom trees,2/3 published: juniper tree (1KI) vs broom trees (JOB). 'broom trees' is botanically accurate.,2026-02-10,AI


### PR DESCRIPTION
Closes #11. Clarifies the H0639 editorial references and ULT prompt guidance so dual אַפַּיִם is rendered as 'nostrils' and not confused with 'faces'. Ready for review before merge.