### PR TITLE
fix: route generic man notes to figs-genericnoun

### DIFF
--- a/.claude/agents/issue-identification.md
+++ b/.claude/agents/issue-identification.md
@@ -161,6 +161,7 @@ Read issue-type files from `.claude/skills/issue-identification/` as needed. The
 
 | Keyword | Always Check |
 |---------|--------------|
+| singular "a/an" + noun in a general statement (e.g. "a man who...") | figs-genericnoun |
 | man, men, brothers, sons, fathers | figs-gendernotations |
 | like, as, than | figs-simile before figs-metaphor |
 | hand, hands, eyes, heart, face | figs-metonymy or figs-synecdoche |

--- a/.claude/skills/issue-identification/SKILL.md
+++ b/.claude/skills/issue-identification/SKILL.md
@@ -250,6 +250,7 @@ When you encounter these words, ALWAYS check the specific issue listed:
 
 | Keyword | Always Check |
 |---------|--------------|
+| singular "a/an" + noun in a general statement (e.g. "a man who...") | figs-genericnoun |
 | man, men, brothers, sons, fathers | figs-gendernotations (generic masculine?) |
 | like, as, than | figs-simile before figs-metaphor |
 | hand, hands, eyes, face | figs-metonymy or figs-synecdoche (body part for action/person?) |

--- a/.claude/skills/issue-identification/figs-gendernotations.md
+++ b/.claude/skills/issue-identification/figs-gendernotations.md
@@ -52,6 +52,7 @@ Do NOT use figs-gendernotations for:
 - Write notes when **masculine terms include women but readers might not realize this**
 - For **frequent phrases** (e.g., "the sons of Israel"), discuss in introduction; do not write notes to every instance
 - **Not necessary** to write notes to words like "person" that are feminine in Hebrew but already inclusive in English
+- Singular generic phrases like "a man who..." belong in figs-genericnoun instead of figs-gendernotations
 - For gentilics (Jezreelitess, Shunammitess), ULT uses gendered forms matching Hebrew; this is separate from figs-gendernotations
 
 ## Categories
@@ -66,6 +67,7 @@ Do NOT use figs-gendernotations for:
 - **man** (anthropos, adam, ish, enosh, geber) -> "person" or "human"
 - **men** (anthropoi, anashim) -> "people" or "humans"
 - **mankind/humanity** references
+- Singular generic phrases like "a man who..." belong in figs-genericnoun instead
 
 ### 3. Third-Person Pronouns
 - Generic **he/him/his** in proverbs, laws, general statements


### PR DESCRIPTION
Closes #12. Refines issue-identification guidance so singular generic phrases like 'a man who...' are classified as figs-genericnoun instead of figs-gendernotations, and adds an explicit cross-reference in figs-gendernotations. Ready for review before merge.