### PR TITLE
fix: ULT draft relative clause handling in ISA 51

### DIFF
--- a/.claude/skills/ULT-gen/reference/literalness_patterns.md
+++ b/.claude/skills/ULT-gen/reference/literalness_patterns.md
@@ -58,6 +58,15 @@ Keep verb + noun form rather than verb + adverb:
 | asah tsedaqah | "do righteousness" | "act righteously" |
 | dibber shalom | "speak peace" | "speak peacefully" |
 
+## Relative Clauses
+
+Do not turn a Hebrew verbal clause into an English relative clause just because it modifies a noun.
+
+- **Participles** should stay participial: use "-ing" forms, agent nouns, or "the ones/those [verb]-ing" where needed.
+- **Indicatives / finite verbs** should stay finite: use a plain English verb without prepending "who/that".
+
+Use a relative clause only when the Hebrew syntax actually requires one.
+
 ## Comparative Constructions
 
 Comparatives with מִן use English comparative form:


### PR DESCRIPTION
Closes #21. Adds a literalness rule that keeps participles participial and finite verbs finite instead of falling back to relative clauses like who/that when rendering Hebrew verbal clauses. Ready for review before merge.