### PR TITLE
fix: no continuer quotation marks at mid-passage verse starts

### DIFF
--- a/.claude/skills/ULT-gen/SKILL.md
+++ b/.claude/skills/ULT-gen/SKILL.md
@@ -441,6 +441,7 @@ Before finalizing ULT output, verify:
 - [ ] לְ + role/status nouns stay prepositional ("as a servant"), not infinitival ("to be a servant")
 - [ ] Selah uses `\qs Selah \qs*` format on its own line (space after Selah before closing tag)
 - [ ] Emphatic doubling preserved without adding words ("day, day" not "day {by} day")
+- [ ] Quotation marks placed only at the very start and very end of a direct quotation block — **no continuer (opening) mark at the start of mid-passage verses** within an ongoing quotation (gl_guidelines.md §Quotation Marks)
 
 ---
 


### PR DESCRIPTION
Closes #23.

## What changed

Added an explicit quality-checklist item to `ULT-gen/SKILL.md` that prohibits placing a continuer (opening) quotation mark at the start of mid-passage verses within an ongoing direct quotation block. Quotation marks must appear only at the very start and very end of the full quotation.

## Why

The underlying rule already existed in `reference/gl_guidelines.md` §Quotation Marks ("Do NOT put quotes at the start of each verse in continuous speech") but was not surfaced in the generator's own quality checklist. As a result, the ULT-gen missed the check and placed an incorrect opening quote at the start of ISA 51:7 (mid-passage inside a multi-verse direct quotation).

## Verification

Checklist item confirmed present at line 444 of `ULT-gen/SKILL.md`. No tests exist for SKILL.md prose rules; human review on next ISA 51 run will confirm the fix.

Ready for review before merge.