### PR TITLE
fix: render Hebrew jussives as 'May you not…' not imperatives (closes #24)

### DIFF
--- a/.claude/skills/ULT-gen/SKILL.md
+++ b/.claude/skills/ULT-gen/SKILL.md
@@ -139,8 +139,10 @@ Consult `reference/literalness_patterns.md` for these patterns:
 | Infinitive construct | "to [verb]" |
 | Infinitive absolute | Show reduplication: "acquitting he will not acquit" (not "certainly") |
 | Participle | Present tense; NO brackets for be-verb |
-| Imperative | Command form |
-| Jussive/Cohortative | "Let him/me..." or subjunctive |
+| Imperative | Command form ("Do not fear") |
+| Jussive (3rd person) | "May he/she/they [verb]" (not "Let him/them...") |
+| Jussive (2nd person negative, אַל) | "May you not [verb]" (NEVER imperative "Do not [verb]") |
+| Cohortative (1st person) | "Let me/us [verb]" |
 
 Keep finite verbs as plain finite clauses; do not prepend relative pronouns such as "who" or "that" to indicative verbs.
 
@@ -155,6 +157,20 @@ Hebrew cohortatives (1cs/1cp with ה- ending or lengthened form) express desire 
 - אֶשְׁמֹרָה -> "Let me wait" (not "I will watch")
 - אֲזַמֵּרָה -> "Let me make music" (not "I will make music")
 
+#### Jussive Recognition
+
+Hebrew jussives (shortened yiqtol, modal/optative mood) express wishes, prayers, or permissions — never commands. They must **never** be rendered as English imperatives.
+
+**Negative jussive (2nd person, with אַל):** Render as "May you not [verb]" — NOT as an imperative "Do not [verb]":
+- אַל־תִּירְאִי -> "May you not fear" (not "Do not fear")
+- אַל־תֵּחַת -> "May you not be dismayed" (not "Do not be dismayed")
+- The negative particle אַל with a jussive form marks an optative wish, not a prohibition command. Distinguish carefully from לֹא + imperative, which is a true command.
+
+**Positive jussive (3rd person):** Render as "May he/she/they [verb]" — NOT "Let him/her/them [verb]":
+- Reserve "Let him/them..." for cohortatives (1st person).
+- In petitionary or doxological contexts, read shortened yiqtols as jussives and render with "May..."
+
+See `data/glossary/project_glossary.md` Phrases section for editorial attestations.
 #### Participle Handling
 
 Participles should use "-ing" forms to preserve their verbal noun quality:
@@ -424,6 +440,7 @@ Before finalizing ULT output, verify:
 - [ ] Formal register maintained throughout
 - [ ] No split infinitives
 - [ ] Cohortatives rendered as "Let me/us..."
+- [ ] Negative jussives rendered as "May you not [verb]" (NEVER as imperative "Do not [verb]"); positive jussives as "May he/they [verb]"
 - [ ] Participles use "-ing" forms and are not flattened into relative clauses ("who/that"), adjectives, or passive shortcuts
 - [ ] Finite verbs stay finite and are not wrapped in relative clauses ("who/that")
 - [ ] Emphatic pronouns preserved ("I, I will...")


### PR DESCRIPTION
Closes #24.

## What changed

Updated `.claude/skills/ULT-gen/SKILL.md` with three targeted additions:

1. **Verb Forms table** — split the single vague `Jussive/Cohortative` row into three precise rows:
   - Jussive (3rd person) → `"May he/she/they [verb]"`
   - Jussive (2nd person negative, אַל) → `"May you not [verb]"` (NEVER imperative)
   - Cohortative (1st person) → `"Let me/us [verb]"`

2. **Jussive Recognition section** (parallel to the existing Cohortative Recognition section) — explains that אַל + jussive marks an optative wish, not a prohibition command, and must not be conflated with לֹא + imperative.

3. **Quality checklist item** — explicit gate for negative and positive jussives before output is finalised.

No verse-specific notes were added to SKILL.md. The project glossary already attests the ruling (PSA 69:6,17; 70:5).

## Root cause

The previous table row `Jussive/Cohortative → "Let him/me…"` gave no guidance for 2nd-person negative jussives (אַל + jussive), causing the generator to fall back to the grammatically similar imperative surface form and produce "Do not fear / Do not be dismayed" instead of "May you not fear / May you not be dismayed" (ISA 51:7).

Ready for review before merge.