### PR TITLE
fix: enforce granular 1-to-1 UST alignment; add Granularity Hierarchy

### DIFF
--- a/.claude/skills/UST-alignment/SKILL.md
+++ b/.claude/skills/UST-alignment/SKILL.md
@@ -66,7 +66,7 @@ Same JSON structure as ULT alignment:
 
 | Aspect | ULT | UST |
 |--------|-----|-----|
-| English arrays | 1-3 words typical | 5-15 words common |
+| English arrays | 1-3 words typical | 1-5 words preferred; larger only when restructuring requires it |
 | Hebrew indices | Usually 1 per entry | Often 3-5 per entry |
 | Split alignment | Rare | Common (same Hebrew index in multiple entries) |
 | `{brackets}` | Grammar additions | Implied information |
@@ -183,31 +183,33 @@ Brackets are **pre-determined** by the UST-gen skill. The alignment skill preser
 
 ## Alignment Principles
 
-### 1. Meaning Groups Over Word-Level Precision
+### 1. Prefer Granular Alignment; Group Only When Necessary
 
-Group Hebrew words that collectively produce a single English phrase. "Smaller" in UST context means phrase-level, not word-level.
+**Default to the smallest unit that is meaningful.** Where one Hebrew word clearly renders one English word or short phrase, align them 1-to-1. Only group multiple Hebrew words together when the English rendering of those words genuinely cannot be divided into smaller pieces.
 
-**Typical UST alignment:**
+**Example where grouping IS justified** (prepositional phrase restructured into a full relative clause — no sub-phrase can be independently assigned):
 ```json
 {"hebrew_indices": [3, 4, 5, 6], "english": ["does", "not", "do", "what", "evil", "people", "tell", "him", "to", "do,"]}
 ```
 
-This groups a negation + verb + preposition-noun + adjective because the UST restructures them into a single clause.
+Large groups like this are **exceptions**, not the default. Before using a group of 4+ Hebrew indices, verify that no smaller split is possible.
 
-### 2. Smaller Groups Still Preferred When Possible
+### 2. Apply the Granularity Hierarchy
 
-Only merge Hebrew words when the meaning genuinely cannot be divided:
+Follow the decision ladder from `reference/ust_alignment_rules.md`: 1-to-1 first, then small N-to-M, then large groups only as a last resort.
 
-**Good -- separated when meaning allows:**
+**Preferred — 1-to-1 or small groups when meaning allows:**
 ```json
 {"hebrew_indices": [1], "english": ["wicked", "people"]},
 {"hebrew_indices": [2], "english": ["are", "like"]}
 ```
 
-**Avoid -- unnecessarily large groups:**
+**Avoid — unnecessarily large groups when the above split is possible:**
 ```json
 {"hebrew_indices": [1, 2, 3, 4], "english": ["wicked", "people", "are", "like", "chaff", "..."]}
 ```
+
+When in doubt, ask: "Can I split this entry into two or three smaller, still-meaningful entries?" If yes, split it.
 
 ### 3. Split Alignment
 

--- a/.claude/skills/UST-alignment/reference/ust_alignment_rules.md
+++ b/.claude/skills/UST-alignment/reference/ust_alignment_rules.md
@@ -4,16 +4,37 @@ Detailed rules for aligning English UST text with Hebrew source.
 
 ## Core Principle
 
-UST alignment shows which Hebrew word(s) contribute meaning to each English phrase. Not word-for-word, but concept-for-phrase. The overarching purpose is to show the user from which Hebrew words the English phrases take their meaning.
+UST alignment shows which Hebrew word(s) contribute meaning to each English phrase. The overarching purpose is to show the user from which Hebrew words the English phrases take their meaning.
 
-Smaller units of alignment are more desirable than larger units. Only merge Hebrew words together when necessary for the sake of alignment of meaning.
+**Default to the smallest possible alignment unit.** Start with 1-to-1 mappings and expand only when the English rendering genuinely cannot be divided. Granularity is a virtue; large groupings are the exception.
+
+## Granularity Hierarchy
+
+Apply this decision ladder in order — stop at the first level that fits:
+
+1. **1-to-1 (preferred)**: One Hebrew word → one English word or short phrase. Use this whenever a single English word or 2–3-word phrase clearly renders a single Hebrew word.
+   ```json
+   {"hebrew_indices": [3], "english": ["Yahweh"]},
+   {"hebrew_indices": [4], "english": ["remember"]},
+   {"hebrew_indices": [5], "english": ["David"]}
+   ```
+
+2. **Small N-to-M (acceptable)**: A small group of 2–3 Hebrew words that together produce a 2–6-word English phrase where the words cannot be assigned individually. Example: a construct chain whose English equivalent is "the house of the king."
+
+3. **Large group (last resort)**: Many Hebrew words collapsed into a long English clause. Reserve this **only** for:
+   - A large image or idiom with no word-level correspondence (e.g., a simile restructured into a subordinate clause)
+   - A parallelism that the UST collapses into a single sentence
+   - A rhetorical question restructured as a statement where the entire question maps as a unit
+   - A prepositional phrase expanded into a full relative clause where no sub-phrase can be independently assigned
+
+**Never default to large groups.** If you find yourself assigning 4+ Hebrew indices and 8+ English words to one entry, ask: "Can I split this into two or three smaller entries?" If yes, split it.
 
 ## Key Differences from ULT Alignment
 
 | Aspect | ULT | UST |
 |--------|-----|-----|
 | Goal | Word-level precision | Meaning-level mapping |
-| English per entry | 1-3 words typical | 5-15 words common |
+| English per entry | 1-3 words typical | 1-5 words preferred; larger only when restructuring requires it |
 | Hebrew per entry | Usually 1 | Often 3-5 |
 | Split alignment | Occasional | Very common |
 | Brackets | Grammar additions ({is}, {was}) | Implied information ({when Yahweh}) |
@@ -200,9 +221,11 @@ For reference:
 
 ## What NOT to Do
 
-- **Don't try word-level alignment** -- this is not ULT
+- **Don't default to large groupings** -- if a Hebrew word maps cleanly to a specific English word or phrase, align it 1-to-1 rather than folding it into a large multi-word entry
+- **Don't merge just because words are adjacent** -- adjacency in the Hebrew does not mean they must be grouped; only merge when the English rendering genuinely cannot be divided into smaller pieces
+- **Don't treat the UST's meaning-based approach as license to always group** -- the UST is meaning-based, but that does not mean every alignment entry must cover multiple Hebrew words; prefer granularity
 - **Don't bracket words that are simply restructured** from Hebrew (restructuring is not the same as implying)
-- **Don't split groups that represent a single meaning unit** -- if the entire clause renders one Hebrew concept, keep it together
+- **Don't split groups that represent a single, inseparable meaning unit** -- if an entire clause renders one Hebrew concept with no divisible sub-parts, keep it together
 - **Don't merge groups that represent distinct meaning units** -- if two Hebrew words contribute distinct meanings to different parts of the English, keep them separate
 - **Don't leave Hebrew words unaligned** when they have meaning correspondence in the UST -- only leave unaligned if the Hebrew word truly has no representation
 - **Don't align implied info with later Hebrew words** -- implied information can only point backward


### PR DESCRIPTION
Closes #49.

## Summary

UST alignment was producing overly broad groupings because the skill guidance described "5-15 words common" as the typical case and framed meaning-group alignment as the default mode. This change enforces granular (1-to-1) alignment as the default.

## Changes

### `reference/ust_alignment_rules.md`
- **Core Principle**: Replaced the weak "smaller units are preferable" statement with an explicit mandate: "Default to the smallest possible alignment unit. Start with 1-to-1 mappings and expand only when the English rendering genuinely cannot be divided."
- **New section — Granularity Hierarchy**: Three-level decision ladder: (1) 1-to-1 preferred, (2) small N-to-M acceptable, (3) large group only as last resort, with concrete examples for each level and an explicit list of the only cases where large groups are justified.
- **What NOT to Do**: Added three new bullets explicitly against defaulting to large groupings and merging merely because words are adjacent.
- **Key Differences table**: Fixed "5-15 words common" → "1-5 words preferred; larger only when restructuring requires it".

### `SKILL.md`
- **Section 1** renamed from "Meaning Groups Over Word-Level Precision" (which implicitly encouraged grouping) to "Prefer Granular Alignment; Group Only When Necessary".
- **Section 2** renamed to "Apply the Granularity Hierarchy" with a cross-reference to the decision ladder and an explicit "When in doubt, split" prompt.
- **Key Differences table**: Same fix as above.