### PR TITLE
ci: wake auto-handler on issue events from this repo

### DIFF
--- a/.github/workflows/issue-event-fly-machine-start.yml
+++ b/.github/workflows/issue-event-fly-machine-start.yml
@@ -1,0 +1,39 @@
+name: Start Fly Issue Handler Machine (Issue Events)
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+  workflow_dispatch:
+
+concurrency:
+  group: fly-start-issue-${{ github.event.issue.id || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  start-machine:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.issue.user.login == 'deferredreward'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Start Fly Machine
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_APP_NAME: ${{ secrets.FLY_APP_NAME }}
+        run: |
+          set -euo pipefail
+          test -n "$FLY_API_TOKEN"
+          test -n "$FLY_APP_NAME"
+          machine_id="$(flyctl machines list --app "$FLY_APP_NAME" --json \
+            | node -e "let s=''; process.stdin.on('data',c=>s+=c); process.stdin.on('end',()=>{ try { const j=JSON.parse(s); const m=Array.isArray(j)?j.find(x=>x&&x.id&&String(x.state||'').toLowerCase()!=='destroyed'):null; if (m) process.stdout.write(m.id); } catch {} });")"
+          if [ -z "$machine_id" ]; then
+            echo "Could not resolve a non-destroyed machine for app $FLY_APP_NAME" >&2
+            flyctl machines list --app "$FLY_APP_NAME" >&2 || true
+            exit 1
+          fi
+          echo "Resolved machine: $machine_id"
+          flyctl machine update "$machine_id" --app "$FLY_APP_NAME" --yes --skip-start --restart no
+          flyctl machine start "$machine_id" --app "$FLY_APP_NAME"

--- a/.github/workflows/issue-event-fly-machine-start.yml
+++ b/.github/workflows/issue-event-fly-machine-start.yml
@@ -11,6 +11,9 @@ concurrency:
   group: fly-start-issue-${{ github.event.issue.id || github.run_id }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   start-machine:
     if: >-
@@ -35,5 +38,12 @@ jobs:
             exit 1
           fi
           echo "Resolved machine: $machine_id"
+          state="$(flyctl machines list --app "$FLY_APP_NAME" --json \
+            | node -e "let s=''; process.stdin.on('data',c=>s+=c); process.stdin.on('end',()=>{ try { const j=JSON.parse(s); const m=Array.isArray(j)?j.find(x=>x&&x.id===process.argv[1]):null; if (m) process.stdout.write(String(m.state||'')); } catch {} });" "$machine_id" || echo "")"
+          echo "Current machine state: ${state:-(unknown)}"
+          if [ "$state" = "started" ] || [ "$state" = "starting" ]; then
+            echo "Machine already running; skipping update + start."
+            exit 0
+          fi
           flyctl machine update "$machine_id" --app "$FLY_APP_NAME" --yes --skip-start --restart no
-          flyctl machine start "$machine_id" --app "$FLY_APP_NAME"
+          flyctl machine start "$machine_id" --app "$FLY_APP_NAME" || true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/issue-event-fly-machine-start.yml` so opening or labeling an issue here immediately wakes the `bp-assistant-auto-issue-handler` Fly machine via `flyctl machine start`.
- Author guard limits triggering to `deferredreward`; finer-grained skip filtering happens in-machine after the wake.
- Concurrency keyed on issue id matches the pattern used in the auto-handler repo's existing wakers.

## Why

The matching workflow at `deferredreward/bp-assistant-auto-issue-handler/.github/workflows/issue-event-fly-machine-start.yml` has never fired from an `issues` event — that trigger only listens for events in the workflow's own repo. Sibling PR in `unfoldingWord/bp-assistant` adds the same workflow there; a cleanup PR in the auto-handler repo removes the dormant version.

This relies on `FLY_API_TOKEN` already being available in this repo (it's used today by `review-gate.yml`). `FLY_APP_NAME` at repo level points at the auto-handler app.

## Test plan

- [ ] Review-gate passes
- [ ] After merge, open a throwaway test issue here (close immediately); confirm the new workflow fires within ~30s
- [ ] Confirm the auto-handler Fly machine transitions `stopped` → `started` → `stopped`

🤖 Generated with [Claude Code](https://claude.com/claude-code)