### PR TITLE
fix(tq-writer): make 3-digit chapter padding explicit in output filename

### DIFF
--- a/.claude/skills/tq-writer/SKILL.md
+++ b/.claude/skills/tq-writer/SKILL.md
@@ -67,15 +67,15 @@ Rules for AI updates:
 - Follow tq-guidelines.md for content rules (third person, present tense, ESL level, etc.)
 - If a row already matches the current ULT/UST, leave it unchanged
 
-Write the result as a TSV file to `output/tq/{BOOK}/{BOOK}-{CHAPTER}.tsv` (zero-padded chapter, e.g., `PSA/PSA-150.tsv`), or `output/tq/{BOOK}/{BOOK}.tsv` for whole-book processing.
+Write the result as a TSV file to `output/tq/{BOOK}/{BOOK}-{CHAPTER}.tsv` (chapter zero-padded to 3 digits, e.g., `PSA/PSA-006.tsv` for chapter 6, `PSA/PSA-023.tsv` for chapter 23, `PSA/PSA-150.tsv` for chapter 150), or `output/tq/{BOOK}/{BOOK}.tsv` for whole-book processing.
 
 ### Step 5: Post-Process Quotes
 
-Use `mcp__workspace-tools__curly_quotes` with `input="output/tq/PSA/PSA-150.tsv"`, `inPlace=true`.
+Use `mcp__workspace-tools__curly_quotes` with `input="output/tq/PSA/PSA-006.tsv"`, `inPlace=true`.
 
 ### Step 6: Verify Output
 
-Use `mcp__workspace-tools__verify_tq` with `tsvFile="output/tq/PSA/PSA-150.tsv"`, `inputJson="/tmp/claude/prepared_tq.json"`.
+Use `mcp__workspace-tools__verify_tq` with `tsvFile="output/tq/PSA/PSA-006.tsv"`, `inputJson="/tmp/claude/prepared_tq.json"`.
 
 ### Step 7: Insertion (when ready)
 


### PR DESCRIPTION
Closes unfoldingWord/bp-assistant#49.

## Summary

- The `tq-writer` SKILL.md described the output filename as `(zero-padded chapter, e.g., PSA/PSA-150.tsv)`. Because 150 is naturally 3 digits, the padding width was ambiguous for chapters 1–99.
- The AI agent executing the skill inferred 2-digit padding and wrote `PSA-06.tsv`; the pipeline checks for `PSA-006.tsv` (3-digit, matching `padStart(3, '0')` in `tqs-pipeline.js`), so the file was never found and the chapter was marked failed.
- This failure recurred twice within ~75 minutes for PSA 6 before being diagnosed.

## Changes

- **Line 70** — changed `(zero-padded chapter, e.g., PSA/PSA-150.tsv)` to `(chapter zero-padded to 3 digits, e.g., PSA/PSA-006.tsv for chapter 6, PSA/PSA-023.tsv for chapter 23, PSA/PSA-150.tsv for chapter 150)`.
- **Lines 74 & 78** — updated example paths in Steps 5 and 6 from `PSA-150.tsv` to `PSA-006.tsv` so the low-chapter pattern is reinforced throughout the skill.

## Test plan

- [ ] Re-run TQS pipeline for PSA 6 and confirm the writer produces `output/tq/PSA/PSA-006.tsv`
- [ ] Verify Steps 5 and 6 tool calls use the correct path