### PR TITLE
fix: prevent \u escape sequences in chapter intro TSV output

### DIFF
--- a/.claude/skills/chapter-intro/SKILL.md
+++ b/.claude/skills/chapter-intro/SKILL.md
@@ -114,7 +114,7 @@ Use `[[rc://*/tw/dict/bible/kt/<term>]]` or `[[rc://*/tw/dict/bible/other/<term>
 ### Step 5: Format and Insert into Issue File
 
 **Format the intro for TSV storage:**
-1. Escape all newlines as literal `\n` (two characters: backslash + n)
+1. Escape actual newline characters as literal `\n` (two characters: backslash + n). **This is the ONLY escaping needed.** Do NOT escape Unicode characters — en-dashes (–), em-dashes (—), curly quotes (“ ” ‘ ’), apostrophes (’), or any other non-ASCII character — as `\u` sequences. Write all such characters as their actual Unicode characters.
 2. The intro content goes in column 7 (the explanation/content column)
 
 **Build the issue TSV row (7 tab-separated columns, matching issue TSV format):**
@@ -146,3 +146,4 @@ If the issue file already has an intro row (first line contains `:intro`), repla
 **Confirm the result** by reading back the first 3 lines of the file to verify:
 1. The intro row is correctly placed as the first data line
 2. The intro is a **single TSV line** — no actual newline characters in the content. All markdown line breaks must be literal two-character `\n` sequences. If you see the intro spanning multiple lines in the file, fix it immediately.
+3. There are no `\u` escape sequences in the content (e.g., `\u2013`, `\u201c`). If you see any, the file must be rewritten with the actual Unicode characters substituted in place of the escape sequences.


### PR DESCRIPTION
Closes #53.

## Summary

- The `chapter-intro` SKILL.md Step 5 instructed Claude to escape newlines as literal `\n` but was silent on other characters, causing Claude to over-apply JSON-style escaping to Unicode characters (en-dashes `–`, em-dashes `—`, curly quotes `" "`, apostrophes `'`)
- This produced literal `–`, `“`, `’` etc. in the intro TSV column instead of the actual Unicode characters, confirmed in Zechariah 5:intro (ZEC notes line 206)
- Fixed by: (1) clarifying that `\n` is the **only** escaping required, (2) explicitly forbidding `\u`-style escaping of non-ASCII characters, and (3) adding a third confirmation check so the model can self-detect and self-correct any residual escape sequences before finishing

## What changed

`.claude/skills/chapter-intro/SKILL.md` — Step 5 "Format and Insert into Issue File":
- Item 1: `"Escape all newlines…"` → `"Escape actual newline characters… This is the ONLY escaping needed. Do NOT escape Unicode characters … as \u sequences."`
- Added item 3 to the "Confirm the result" checklist: scan for `\u` escape sequences and remediate if found

## Note on companion fix needed

`tn-tools.js` in `bp-assistant` (the `assembleNotes` function, lines 1225–1237) does not call `decodeVisibleUnicodeEscapes` on intro-row content, while regular notes do receive this treatment via `normalizeAssembledNoteText` (line 1019). That is a defensive code fix needed in the `bp-assistant` repo to catch any escapes that slip through.

## Test plan

- [ ] Verify chapter intro generation for any OT book produces actual `–` and `"` characters in the issue TSV (not `–` or `“`)
- [ ] Inspect the assembled output TSV intro row to confirm no `\u` escape sequences in the Note column