### PR TITLE
fix(tq-writer): preserve multi-verse reference spans in output

### DIFF
--- a/.claude/skills/tq-writer/SKILL.md
+++ b/.claude/skills/tq-writer/SKILL.md
@@ -63,7 +63,8 @@ Rules for AI updates:
 - Return the full set of rows for the chapter (not just changed ones)
 - Preserve existing IDs -- do not change the ID column
 - Preserve Tags, Quote, and Occurrence columns as-is (usually empty)
-- Only modify Reference (if verse range changed), Question, and Response
+- Only modify Reference (if the ULT/UST content has genuinely moved to a different verse), Question, and Response
+- **Multi-verse reference spans**: if the source row carries a range reference (e.g., `18:9-10`, `24:1-2`), copy it exactly into the output — do NOT collapse it to only the first verse
 - Follow tq-guidelines.md for content rules (third person, present tense, ESL level, etc.)
 - If a row already matches the current ULT/UST, leave it unchanged
 

--- a/.claude/skills/tq-writer/reference/tq-guidelines.md
+++ b/.claude/skills/tq-writer/reference/tq-guidelines.md
@@ -54,6 +54,7 @@ TQ answers should capture the *idea* of the content so that any translation deri
 ### Verse References
 - Verify that verse references in the Reference column match the actual content of the question and answer
 - If a question spans multiple verses, use range notation (e.g., 150:3-5)
+- **Preserve multi-verse reference spans exactly** — if the source row is `18:9-10` or `24:1-2`, the output must carry that same range. Never collapse a span to only the first verse number; a narrowed reference fails downstream merge/delete matching and produces duplicate rows.
 - Ensure the answer can be found in the referenced verse(s)
 
 ## Update Rules


### PR DESCRIPTION
Closes #58.

## Summary

- **Root cause**: The `Rules for AI updates` bullet in `SKILL.md` said _"Only modify Reference (if verse range changed)"_ — ambiguous enough that the AI writer treated multi-verse spans like `18:9-10` or `24:1-2` as eligible to "fix" down to a single verse number.
- **Fix 1 (`SKILL.md`)**: Clarified the bullet so it only permits modifying the Reference when ULT/UST content has _genuinely moved to a different verse_. Added an explicit adjacent bullet: _"Multi-verse reference spans: if the source row carries a range reference (e.g., `18:9-10`, `24:1-2`), copy it exactly into the output — do NOT collapse it to only the first verse."_
- **Fix 2 (`tq-guidelines.md`)**: Added a "Preserve multi-verse reference spans exactly" bullet to the existing Verse References section, calling out exactly the failure mode (collapsed ref → broken downstream merge/delete → duplicate rows `qw0f`, `bcbs`, `fhve`).

## Test plan

- [ ] Re-run TQ generation for Psalms chapters containing multi-verse refs (e.g., Ps 18, Ps 24) and confirm `Ref` field carries the full span
- [ ] Verify `mcp__workspace-tools__verify_tq` passes with no duplicate-row warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)