### PR TITLE
fix: require 'the psalmist' not 'the writer' in PSA TQs

### DIFF
--- a/.claude/skills/tq-writer/reference/tq-guidelines.md
+++ b/.claude/skills/tq-writer/reference/tq-guidelines.md
@@ -31,6 +31,13 @@ TQ answers should capture the *idea* of the content so that any translation deri
 - Do not write from the reader's perspective ("you should...") or first-person
 - Example: "What does David say about Yahweh?" not "What should you know about Yahweh?"
 
+### Author References in Psalms (PSA)
+- When referring to the human author of a psalm, use **"the psalmist"** — never "the writer" or "the author"
+- If the psalm's superscription attributes it to a named author (e.g., David, Asaph, the sons of Korah), use that name instead
+- This applies consistently across all PSA TQ questions and responses
+- Good: "What does the psalmist say Yahweh does for him?"
+- Avoid: "What does the writer say about God?" or "What does the author claim?"
+
 ### Pronoun-Antecedent Agreement
 - Ensure pronouns clearly refer to their antecedents
 - When the antecedent is ambiguous, use the noun instead of a pronoun


### PR DESCRIPTION
Closes #68.

## Summary

Adds an explicit **Author References in Psalms (PSA)** rule to `.claude/skills/tq-writer/reference/tq-guidelines.md` that:

- Requires **"the psalmist"** when referring to the human author in PSA TQ questions and responses
- Prohibits "the writer" and "the author" as author references in Psalms
- Allows the named author (e.g., David, Asaph, the sons of Korah) when the superscription attributes the psalm

The existing examples in the file already used "the psalmist", but there was no binding rule, allowing the AI to fall back to the generic "the writer". This fix closes that gap with an explicit prohibition.

Consistent with the same rule already in `tn-writer/reference/note-style-guide.md` (line 118–121) and `tn-quality-check/SKILL.md` (line 213).