### PR TITLE
fix: mirror divine name 'Yahweh' from ULT/UST in TQ questions and responses

### DIFF
--- a/.claude/skills/tq-writer/reference/tq-guidelines.md
+++ b/.claude/skills/tq-writer/reference/tq-guidelines.md
@@ -16,7 +16,7 @@ TQ answers should capture the *idea* of the content so that any translation deri
 - Questions and responses must match the *ideas* in the ULT, not its literal wording
 - The ULT often preserves Hebrew idioms and structures that would confuse ESL readers -- express the same idea in plain, accessible English
 - Use key terms from the ULT (proper nouns, theological terms like "covenant faithfulness") but restate Hebrew idioms in natural English
-- If the ULT uses "Yahweh," the TQ should use "Yahweh" (not "the LORD")
+- If the ULT or UST uses "Yahweh" in a verse, both the question and the response for that verse must also use "Yahweh" — never substitute "God", "the LORD", or any other form for the divine name
 - Example: ULT says "for length of days" -- the TQ answer should say "for as long as he lives," not repeat the Hebrew idiom
 - Example: ULT says "waters of rest" -- the TQ answer should say "quiet waters" or "peaceful waters"
 - The test: could an ESL reader understand the answer without needing to look up what the phrase means?


### PR DESCRIPTION
Closes #72.

## What changed

Strengthened the Yahweh rule in `.claude/skills/tq-writer/reference/tq-guidelines.md` (one line, most specific file):

**Before:**
> If the ULT uses "Yahweh," the TQ should use "Yahweh" (not "the LORD")

**After:**
> If the ULT or UST uses "Yahweh" in a verse, both the question and the response for that verse must also use "Yahweh" — never substitute "God", "the LORD", or any other form for the divine name

Three gaps were closed:
1. Trigger now covers **either** ULT **or** UST (not ULT alone)
2. Rule now explicitly covers the **response** as well as the **question**
3. Prohibited substitutions now include "God" and "any other form", not just "the LORD"