### PR TITLE
fix: TQ writer should use UST non-figurative language for questions and answers

### DIFF
--- a/.claude/skills/tq-writer/SKILL.md
+++ b/.claude/skills/tq-writer/SKILL.md
@@ -50,7 +50,7 @@ Read `/tmp/claude/prepared_tq.json`. For each chapter:
 
 1. Read the existing TQ rows from `tq_rows_by_chapter`
 2. Read the ULT text from `ult_by_verse` and UST text from `ust_by_verse`
-3. Compare each TQ row's question and response against the current ULT/UST
+3. Compare each TQ row's question and response against the current ULT and UST; **use the UST's non-figurative wording as the primary source for plain-language phrasing in both questions and responses** — where the ULT uses figurative language, the UST's rendering takes precedence
 4. Update rows where needed following the guidelines
 
 **Output format:** Write updated TSV rows to the output file, one chapter at a time. Include the header row. Use the same 7-column format:

--- a/.claude/skills/tq-writer/reference/tq-guidelines.md
+++ b/.claude/skills/tq-writer/reference/tq-guidelines.md
@@ -13,12 +13,14 @@ TQ answers should capture the *idea* of the content so that any translation deri
 ## Content Rules
 
 ### Match the Content, Not the Form
-- Questions and responses must match the *ideas* in the ULT, not its literal wording
-- The ULT often preserves Hebrew idioms and structures that would confuse ESL readers -- express the same idea in plain, accessible English
-- Use key terms from the ULT (proper nouns, theological terms like "covenant faithfulness") but restate Hebrew idioms in natural English
+- Questions and responses must match the *ideas* in the content, using plain, non-figurative language
+- **Prefer UST non-figurative wording**: The UST is the authoritative source of plain-language renderings. When the ULT uses figurative language (idioms, metaphors, symbolic images), always check the UST first and use its non-figurative wording in both the question and the response. Do not independently paraphrase ULT figures when the UST already provides a plain equivalent.
+- This applies to both questions and responses — if the ULT says "the apple of his eye" and the UST says "the one he cares for most," both the question and response must use the UST's plain phrasing, not the ULT's figure
+- The ULT often preserves Hebrew idioms and structures that would confuse ESL readers -- the UST's rendering is the authoritative guide for expressing the same idea in plain, accessible English
+- Use key terms from the ULT (proper nouns, theological terms like "covenant faithfulness") but restate Hebrew idioms following the UST wording
 - If the ULT or UST uses "Yahweh" in a verse, both the question and the response for that verse must also use "Yahweh" — never substitute "God", "the LORD", or any other form for the divine name
-- Example: ULT says "for length of days" -- the TQ answer should say "for as long as he lives," not repeat the Hebrew idiom
-- Example: ULT says "waters of rest" -- the TQ answer should say "quiet waters" or "peaceful waters"
+- Example: ULT says "for length of days"; UST says "as long as he lives" — the TQ answer should say "as long as he lives," not repeat the Hebrew idiom
+- Example: ULT says "waters of rest"; UST says "quiet streams of water" — the TQ answer should say "quiet water," following the UST's non-figurative rendering
 - The test: could an ESL reader understand the answer without needing to look up what the phrase means?
 
 ### Language Level


### PR DESCRIPTION
Closes #76.

## Summary

- Added explicit rule to `tq-guidelines.md` (`Match the Content, Not the Form` section): the UST is the authoritative plain-language source. When the ULT uses figurative language, the AI must check the UST first and use its non-figurative wording in **both** the question and the response — not independently paraphrase ULT figures.
- Updated `SKILL.md` Step 4 item 3 to reinforce the UST-first rule at the workflow level so the instruction is encountered during execution.

## What changed

Two targeted edits to the tq-writer skill:
1. `reference/tq-guidelines.md` — expanded "Match the Content, Not the Form" with a bolded UST-preference rule, an explicit note that it covers both questions and responses, updated examples showing UST wording, and reworded the existing "express the same idea" bullet to make the UST the named authority.
2. `SKILL.md` — rewrote Step 4 item 3 to call out UST non-figurative wording as the primary source.

## Verification

Changes are documentation/guidance only (no executable code). Correctness verified by reading the updated files and confirming the new rules are unambiguous and consistent with existing TQ workflow steps.