### PR TITLE
fix: prefer ULT language by default in TQ writing; fall back to UST for metaphor/complex text

### DIFF
--- a/.claude/skills/tq-writer/SKILL.md
+++ b/.claude/skills/tq-writer/SKILL.md
@@ -50,7 +50,7 @@ Read `/tmp/claude/prepared_tq.json`. For each chapter:
 
 1. Read the existing TQ rows from `tq_rows_by_chapter`
 2. Read the ULT text from `ult_by_verse` and UST text from `ust_by_verse`
-3. Compare each TQ row's question and response against the current ULT and UST; **use the UST's non-figurative wording as the primary source for plain-language phrasing in both questions and responses** — where the ULT uses figurative language, the UST's rendering takes precedence
+3. Compare each TQ row's question and response against the current ULT and UST; **default to ULT language** for questions and responses; **fall back to UST language only when the ULT rendering is metaphorical, uses Hebrew idioms, or is otherwise not plain/accessible English** — use the UST's non-figurative wording for those cases
 4. Update rows where needed following the guidelines
 
 **Output format:** Write updated TSV rows to the output file, one chapter at a time. Include the header row. Use the same 7-column format:

--- a/.claude/skills/tq-writer/reference/tq-guidelines.md
+++ b/.claude/skills/tq-writer/reference/tq-guidelines.md
@@ -14,10 +14,11 @@ TQ answers should capture the *idea* of the content so that any translation deri
 
 ### Match the Content, Not the Form
 - Questions and responses must match the *ideas* in the content, using plain, non-figurative language
-- **Prefer UST non-figurative wording**: The UST is the authoritative source of plain-language renderings. When the ULT uses figurative language (idioms, metaphors, symbolic images), always check the UST first and use its non-figurative wording in both the question and the response. Do not independently paraphrase ULT figures when the UST already provides a plain equivalent.
+- **Prefer ULT language by default**: Use ULT phrasing for questions and responses whenever the ULT text is plain and accessible to ESL readers — this keeps TQ language close to the source translators are working from.
+- **Fall back to UST for metaphor or complex text**: Switch to UST wording when the ULT rendering is metaphorical, uses Hebrew idioms, or is otherwise not plain/accessible English. Do not independently paraphrase ULT figures when the UST already provides a plain equivalent.
 - This applies to both questions and responses — if the ULT says "the apple of his eye" and the UST says "the one he cares for most," both the question and response must use the UST's plain phrasing, not the ULT's figure
-- The ULT often preserves Hebrew idioms and structures that would confuse ESL readers -- the UST's rendering is the authoritative guide for expressing the same idea in plain, accessible English
-- Use key terms from the ULT (proper nouns, theological terms like "covenant faithfulness") but restate Hebrew idioms following the UST wording
+- The ULT often preserves Hebrew idioms and structures that would confuse ESL readers — in those cases the UST's rendering is the guide for expressing the same idea in plain, accessible English
+- Always use key terms from the ULT (proper nouns, theological terms like "covenant faithfulness"); only substitute UST wording for figurative or complex ULT expressions
 - If the ULT or UST uses "Yahweh" in a verse, both the question and the response for that verse must also use "Yahweh" — never substitute "God", "the LORD", or any other form for the divine name
 - Example: ULT says "for length of days"; UST says "as long as he lives" — the TQ answer should say "as long as he lives," not repeat the Hebrew idiom
 - Example: ULT says "waters of rest"; UST says "quiet streams of water" — the TQ answer should say "quiet water," following the UST's non-figurative rendering


### PR DESCRIPTION
Closes #77.

## Summary

- Updated `tq-writer/SKILL.md` Step 4 instruction to direct the AI to **default to ULT language** and only fall back to UST when the ULT rendering is metaphorical, uses Hebrew idioms, or is not plain/accessible English.
- Updated `tq-writer/reference/tq-guidelines.md` "Match the Content, Not the Form" section to replace the old "Prefer UST non-figurative wording" rule with two explicit priority rules:
  1. **Prefer ULT language by default** (when ULT text is plain and accessible)
  2. **Fall back to UST for metaphor or complex text** (when ULT is figurative/idiomatic)

This aligns TQ-writing guidance with the editorial direction from Beth Oakes (stream: 81 English Book Packages, message ID: 593995085): TQs should use ULT phrasing wherever possible so they stay close to what translators are working from, only switching to UST where the ULT itself is metaphorical or too complex for ESL readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)