### PR TITLE
fix: omit final punctuation from AT snippets in TN see_how_at_prompt

### DIFF
--- a/.claude/skills/tn-writer/reference/prompt-templates.md
+++ b/.claude/skills/tn-writer/reference/prompt-templates.md
@@ -81,6 +81,8 @@ issue type: {sref}
 
 blank template: {template}
 
+Do not include final punctuation in the alternate translation. Do not end the AT text with a period, question mark, exclamation mark, or comma — even if the ULT text being replaced ends with one. The AT replaces the *words*, not the surrounding punctuation. The only exception is a `figs-rquestion` note, where changing `?` to `.` or `!` is the explicit point of the note.
+
 Return only the text of the generated alternate translation.
 ```
 


### PR DESCRIPTION
Closes #80.

## Summary

- The "Punctuation in ATs" rule already existed in `note-style-guide.md` (do not add ending punctuation in AT brackets unless specifically proposing a punctuation change).
- That rule was absent from `see_how_at_prompt` in `prompt-templates.md`, so when Claude generated ATs via that template for "see how" reference notes, the constraint was not in context.
- Added an explicit no-ending-punctuation instruction to `see_how_at_prompt`, matching the existing style-guide rule and its `figs-rquestion` exception.

## What changed

`prompt-templates.md` (`see_how_at_prompt`): added five lines before `Return only the text…` stating that ATs must not end with `.`, `?`, `!`, or `,`, with the sole exception of `figs-rquestion` notes where the punctuation change is the point.

## Verification

No automated test suite for prompt templates; change is a doc/skill-guidance edit. Manual verification: re-run tn-writer on any verse and confirm the generated AT in the output notes no longer carries a trailing period or question mark.