### PR TITLE
fix: bold-format GLQuote words when directly quoted in Note field

### DIFF
--- a/.claude/skills/tn-writer/SKILL.md
+++ b/.claude/skills/tn-writer/SKILL.md
@@ -175,6 +175,7 @@ Read the assembled TSV alongside the aligned ULT. For each row, verify:
 5. **AT fit** -- if an Alternate Translation is present, mentally substitute it for the GLQuote in the ULT verse and confirm it reads naturally
 6. **Quote scope** -- the Hebrew quote covers the right range (not too narrow or too wide for the issue)
 7. **No duplicate UST phrasing** -- ATs should differ from the UST for the same verse
+8. **Bold formatting** -- every word or phrase quoted verbatim from the GLQuote or ULT verse text in the Note field must appear in `**bold**`. Scan each note for ULT words used without bold and add it. Do not bold any word that does not appear verbatim in the ULT verse.
 
 For `writing-pronouns` rows, apply three extra checks during final review:
 1. If the referent is already obvious from the verse context or made explicit by the UST, remove the note instead of preserving a low-value pronoun explanation.

--- a/.claude/skills/tn-writer/reference/note-style-guide.md
+++ b/.claude/skills/tn-writer/reference/note-style-guide.md
@@ -18,7 +18,7 @@ Follow `../../reference/gl_guidelines.md` for shared style rules (formality, num
 ## Formatting
 
 ### Bold
-In the note, put in markdown bold formatting any words or phrases that you quote from the given text or from the rest of the verse. Only use quotation marks where there may be quotation marks in the original text that you are quoting. Use markdown bold formatting only for the first occurrence of quoted words or phrases. Quotations from other verses in the Bible should be put in quotation marks. Do not bold anything except an exact quote from the verse.
+Every word or phrase quoted verbatim from the GLQuote or from anywhere in the ULT verse **must** appear in Markdown bold (`**word**`) in the note body. This is a required formatting rule, not optional. Whenever you reproduce exact ULT words in the note, wrap them in bold — for example, if the GLQuote is "his steadfast love" and the note explains it, write "**his steadfast love** refers to..." not "his steadfast love refers to...". Only use quotation marks where there are quotation marks in the original text being quoted. Apply bold to the **first occurrence** of each quoted word or phrase only; do not re-bold the same phrase if it appears again later in the same note. Quotations from other verses in the Bible should be put in quotation marks, not bold. Do not bold anything except an exact verbatim quote from the current verse.
 
 ### Capitalization and Grammatical Forms
 When you quote words or phrases from the given text or the rest of the verse, match the capitalization, number, and grammatical forms exactly. For example, if the text says "horses," do not write a note saying, "A **horse** is (definition)." Say, "The term **horses** describes (definition)."


### PR DESCRIPTION
Closes #82.

## Summary

- Strengthened the `### Bold` rule in `note-style-guide.md`: replaced the vague phrase "the given text" with "the GLQuote or from anywhere in the ULT verse", added explicit **must** emphasis, and added a concrete inline example showing `**his steadfast love** refers to...` vs the incorrect unbolded form.
- Added a **Bold formatting** check as item 8 in the Step 7 Final Review checklist in `SKILL.md`, so any missed bold formatting is caught during the review pass.

## Test plan

- [ ] Verify that the updated `### Bold` section in `note-style-guide.md` clearly directs the model to bold all verbatim ULT/GLQuote text in note bodies.
- [ ] Verify the new Step 7 item 8 in `SKILL.md` instructs the reviewer to scan for and fix missing bold formatting.
- [ ] Run the tn-writer skill on a sample passage and confirm quoted ULT words in notes are wrapped in `**bold**`.