### PR TITLE
Enforce valid SupportReference issue types in TN pipeline

### DIFF
--- a/.claude/skills/issue-identification/SKILL.md
+++ b/.claude/skills/issue-identification/SKILL.md
@@ -257,6 +257,7 @@ When you encounter these words, ALWAYS check the specific issue listed:
 | heart | figs-metaphor (heart = thoughts/feelings/will; see template) |
 | all, every, never, always | figs-hyperbole (exaggeration for emphasis?) |
 | the righteous, the wicked, the poor | figs-nominaladj (adjective as noun?) |
+| wordplay, sound play, paronomasia, two words from the same Hebrew root | writing-poetry (there is no figs-paronomasia type — see writing-poetry.md "Similar Sounds") |
 
 ### Commonly Confused Issue Pairs
 
@@ -463,7 +464,7 @@ Format:
 |--------|-------------|
 | book | 3-letter abbreviation (psa, gen, mat, etc.) |
 | chapter:verse | Single-verse reference (78:17). Never use verse ranges — see rules below. |
-| supportreference | Issue type (figs-metaphor, writing-pronouns, etc.) |
+| supportreference | Issue type (figs-metaphor, writing-pronouns, etc.) — must be one of the slugs in `data/translation-issues.csv` / the [issue-types catalog](reference/issue-types-catalog.md). Never coin a new one (no `figs-paronomasia`); if no type fits, pick the closest listed type. |
 | ULT text | English phrase copied verbatim from the ULT — exact words, exact inflections, from one verse only |
 | (empty) | Reserved |
 | (empty) | Reserved |

--- a/.claude/skills/tn-quality-check/SKILL.md
+++ b/.claude/skills/tn-quality-check/SKILL.md
@@ -163,6 +163,10 @@ Guardrails for this step:
 **For quote boundary issues** (restructuring scope, parallelism scope, orphaned words):
 - Use `mcp__workspace-tools__update_prepared_quote` with `preparedJson` (= `runtime.preparedNotes`, or fallback `tmp/claude/prepared_notes.json`), the affected `id`, and the changed `glQuote` / `glQuoteRoundtripped` / `origQuote` fields. Do not hand-`Edit` the JSON.
 
+**For invalid support references** (`unknown_sref` — the issue type is not in the list, e.g. an invented slug like `figs-paronomasia`):
+- The SupportReference must be a valid issue type from `data/translation-issues.csv`. Re-select the correct one rather than deleting the note — Hebrew wordplay / sound play (words from the same root) is `writing-poetry`, not a `figs-paronomasia` of its own.
+- Set the corrected slug with `mcp__workspace-tools__update_prepared_quote`, passing the affected `id` and the `sref` field (e.g. `sref: "writing-poetry"`). If the note text was written for the wrong type, also fix it with `update_note_text`.
+
 **For removal** (antithetical parallelism notes, redundant structural notes):
 - Use `mcp__workspace-tools__remove_note` with the `id`, `generatedJson` (= `runtime.generatedNotes`), and `tsvFile` (the assembled TSV) — it drops the entry from the JSON and the matching TSV row in one call.
 
@@ -211,6 +215,7 @@ The script runs these checks:
  7  gl_quote_not_in_ult             error       gl_quote appears in ULT verse (expected for discontinuous quotes using ... notation)
  8  bold_not_in_ult                 error       Bolded text appears verbatim in ULT verse
  9  rc_link_in_note                 error       Note column has no rc:// links
+17  unknown_sref                    error       SupportReference issue type exists in data/translation-issues.csv (no invented slugs like figs-paronomasia)
 10  orphaned_conjunction/prep       warning     No orphaned words before AT in substitution
 10b dropped_conjunction             warning     gl_quote starts with conjunction but AT drops it
 11  writer_in_psalms                warning     PSA: use attributed name or "the psalmist", never "the writer" or "the author"

--- a/.claude/skills/utilities/regression/regression-checks.json
+++ b/.claude/skills/utilities/regression/regression-checks.json
@@ -1,5 +1,28 @@
 [
   {
+    "issue": "zec6-invalid-sref",
+    "title": "TN: SupportReference must be a valid issue type, never an invented slug",
+    "classification": "global",
+    "stage": "TN",
+    "book": null,
+    "chapter": null,
+    "verse": null,
+    "checks": [
+      {
+        "type": "must_not_match",
+        "pattern": "figs-paronomasia",
+        "flags": "",
+        "explain": "There is no figs-paronomasia issue type. Hebrew wordplay / sound play (words from the same root) uses writing-poetry. Originated in a Zec 6 run that coined the slug."
+      },
+      {
+        "type": "invariant",
+        "name": "valid_support_reference",
+        "explain": "Every SupportReference slug must exist in data/translation-issues.csv. Enforced as an error by tn-quality-check unknown_sref; advisory in this runner."
+      }
+    ],
+    "notes": "Pattern check guards the specific closed bug (figs-paronomasia). The general list-membership invariant is enforced by tn-quality-check check 17 (unknown_sref, error)."
+  },
+  {
     "issue": 82,
     "title": "Bold-format GLQuote words when directly quoted in Note field",
     "classification": "global",


### PR DESCRIPTION
## Problem
A Zec 6 run emitted a translation note with SupportReference `figs-paronomasia` — an invented slug. There is no such issue type; issue types must be selected from the list. The Zech 6:12 wordplay (צֶמַח / יִצְמָח, same root) is sound play, which unfoldingWord classifies as `writing-poetry`.

## Changes
- **issue-identification**: keyword-trigger row routing wordplay / sound play / paronomasia / same-root pairs to `writing-poetry`; constrain the `supportreference` output column to slugs in `translation-issues.csv` (never coined).
- **tn-quality-check**: document the `unknown_sref` check (escalated warning → error in bp-assistant) and add Step 4 fix guidance to re-select a valid type via `update_prepared_quote sref` instead of deleting.
- **regression-checks**: `must_not_match` guard on `figs-paronomasia` (verified fires) plus a `valid_support_reference` invariant.

## Companion
Paired with a bp-assistant PR that escalates the `unknown_sref` gate to error and adds the `sref` field to `update_prepared_quote`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)