### PR TITLE
fix: prevent tn-quality-check from reclassifying figs-metaphor "behold" notes to figs-exclamations

### DIFF
--- a/.claude/skills/tn-quality-check/SKILL.md
+++ b/.claude/skills/tn-quality-check/SKILL.md
@@ -87,6 +87,10 @@ Read the SupportReference column to identify the issue type (e.g., `figs-metapho
 
 Flag notes that describe the wrong issue type.
 
+**Do not reclassify a valid SupportReference.** Step 3a is only for flagging notes whose SupportReference is genuinely wrong. If the note's text already matches the SupportReference template and standard verbiage, leave the SupportReference alone — even if a different issue type might also plausibly apply. The quality-check pass must not overwrite a SupportReference that the issue-identification skill has correctly assigned.
+
+**Specifically: do not change `figs-metaphor` "behold" notes to `figs-exclamations`.** Per `issue-identification/figs-exclamations.md` and `issue-identification/figs-metaphor.md`, "behold" calling attention to information (the vast majority of cases — "Behold, I am sending...", "behold, a man came", "And behold") is **`figs-metaphor`** (speaker says "look" but means "listen/pay attention"). Only the rare case of "behold" expressing genuine visual surprise is `figs-exclamations`. If a note's SupportReference is `figs-metaphor` and the note discusses "behold" as an attention-getter (look = listen), this is correct — do not flag it and do not reclassify it to `figs-exclamations`. Related: "Behold me" (inferior to superior) is `writing-politeness`; "Behold me" (Yahweh announcing action) is `figs-idiom`. None of these should be reclassified to `figs-exclamations` by the quality-check pass.
+
 #### 3b. Template adherence
 
 For each issue type, check that the note follows the template pattern. The note should read like a natural adaptation of the template, not a completely different structure. Flag notes that deviate significantly from the expected template shape.


### PR DESCRIPTION
Closes #103.

## Problem

The `tn-quality-check` skill's Step 3a "Note addresses correct issue type" was overriding correct `figs-metaphor` classifications on "behold" notes and changing them to `figs-exclamations` during semantic review. Per the existing issue-identification rules:

- `issue-identification/figs-exclamations.md` explicitly states that "behold" is **almost always `figs-metaphor`** (look = listen), and the rare visual-surprise case is the only `figs-exclamations` candidate.
- `issue-identification/figs-metaphor.md` confirms "behold" calling attention to information is `figs-metaphor`.
- "Behold me" patterns map to `writing-politeness` (inferior to superior) or `figs-idiom` (Yahweh announcing) — never `figs-exclamations` by default.

So the source-of-truth classification was already correct; the quality-check pass was undoing it.

## Fix

Adds a guardrail to `.claude/skills/tn-quality-check/SKILL.md` Step 3a:

1. General principle: do not reclassify a SupportReference that already matches the note text and template. Step 3a is for flagging genuinely wrong types, not for overwriting valid ones in favor of a "different but also plausible" type.
2. Specific rule: do not change `figs-metaphor` "behold" notes to `figs-exclamations`. Includes the cross-references to `issue-identification/figs-exclamations.md` and `issue-identification/figs-metaphor.md` so future readers can verify.

Smallest fix, in the most specific file (the skill that was making the wrong call), with no chapter-specific examples in top-level SKILL.md.

## Verification

- `npm test` from the worktree: 43/43 pass.
- Diff is +4 lines in `tn-quality-check/SKILL.md`. No data files, no other skill files, no test fixtures touched.

Note: bot was NOT restarted. The live bot picks up changes on the next Docker rebuild.