### PR TITLE
Refine TQ guidelines: question framing and update constraints

### DIFF
--- a/.claude/skills/tq-writer/SKILL.md
+++ b/.claude/skills/tq-writer/SKILL.md
@@ -60,6 +60,10 @@ Reference	ID	Tags	Quote	Occurrence	Question	Response
 ```
 
 Rules for AI updates:
+- This is an update of the existing question set, not a fresh authoring pass. Each existing row produces exactly one updated row; **the chapter's row count and verse References stay the same** unless content genuinely relocated (see guidelines). Do not add questions to improve coverage, and do not re-sequence or compress References to fit a new question order
+- Edit each question's wording in place to reflect the updated ULT/UST; keep its subject and scope. Do not replace a question with a different question on the same row
+- Prefer "what / who / where / when / how" framings; do not introduce new "why" questions (existing why-questions that work stay as-is)
+- Fail safe: if an existing row cannot be confidently matched to a verse in the prepared data, keep it unchanged rather than regenerating it
 - Return the full set of rows for the chapter (not just changed ones)
 - Preserve existing IDs -- do not change the ID column
 - **ID uniqueness is mandatory**: Before emitting each row, check its ID against every ID already written in the current output (across all chapters processed so far in this session). If a collision is detected — including between a single-verse row and a multi-verse range row that covers the same verse — assign a new unique 4-char ID (`[a-z][a-z0-9]{3}`) to the colliding row and confirm the replacement ID is not already in use. Never emit two rows with the same ID.

--- a/.claude/skills/tq-writer/reference/tq-guidelines.md
+++ b/.claude/skills/tq-writer/reference/tq-guidelines.md
@@ -52,6 +52,12 @@ TQ answers should capture the *idea* of the content so that any translation deri
 - Good: "What does the psalmist say about the wicked?"
 - Avoid: "Why is it wrong to follow the wicked?"
 
+### Question Words
+- Prefer "what / who / whom / where / when / how" for comprehension checks — these ask the reader to locate content in the verse
+- Avoid introducing **new** "why" questions, even factual ones (e.g. "Why does Yahweh drive Ephraim out?"). A "why" question asks the reader to supply a reason or causal link, which is closer to interpretation than to plain comprehension, and tends to read as the wrong type
+- An existing "why" question that already functions well and matches the verse should be left as-is — this rule restrains new ones, it does not call for purging inherited ones
+- If the source row's question reflects a cause stated plainly in the verse, prefer a "what" framing: instead of "Why will Yahweh punish them?" use "What does Yahweh say he will do because of their sins?"
+
 ### Indirect Quotations
 - Use indirect quotations rather than direct quotes from the text
 - Good: "According to the psalmist, what does Yahweh do for him?"
@@ -73,6 +79,13 @@ TQ answers should capture the *idea* of the content so that any translation deri
 - Only change what needs to change to align with the updated ULT/UST
 - If the existing TQ already matches the current ULT/UST, leave it unchanged
 - Preserve existing IDs -- do not regenerate IDs for unchanged or lightly edited rows
+- **Edit wording in place; do not re-author.** Keep each existing question's subject and scope, and reword only the parts that the updated ULT/UST changed. Replacing a question with a different question on the same row is not an update — it discards a vetted comprehension check
+- **Preserve the verse Reference; do not renumber.** A row's Reference moves only if the *specific content that question asks about* genuinely relocated to a different verse in the updated text. Do not re-sequence or compress a chapter's references to fit a fresh question order
+- **One row in, one row out.** Each existing row produces exactly one updated row. Do not split one question into several, and do not fold several into one
+
+### Fail Safe When You Cannot Match a Row
+- If you cannot confidently line up an existing TQ row against a verse in `ult_by_verse` / `ust_by_verse` (for example, the verse numbering in the prepared data does not match the row's Reference), keep the row unchanged — same question, same Response, same Reference, same ID
+- Do not respond to a matching gap by regenerating the chapter's questions from the source text. Wholesale regeneration is the failure mode this skill exists to avoid: it inflates the question count, introduces off-type questions, and re-anchors references to the wrong verses
 
 ### What to Update
 - **Terminology**: If the ULT changed a term (e.g., "blessed" -> "happy"), update TQ to match
@@ -82,7 +95,8 @@ TQ answers should capture the *idea* of the content so that any translation deri
 
 ### What Not to Change
 - Do not rewrite well-functioning questions just for style preference
-- Do not add new questions unless existing coverage is clearly insufficient
+- **Hold the question count steady.** This is an update of an existing set, not a fresh authoring pass. Do not add questions to improve coverage or thoroughness. The output for a chapter should have the same number of rows as the input, save for the rare genuine exception below
+- Adding a question is a rare exception, not a default: only when a verse the existing set already covers changed so much that its row no longer has any answerable content, and even then prefer reworking the existing row over adding a new one. If you add a row, it must carry the correct verse Reference and a fresh unique ID
 - Do not remove questions unless they are clearly redundant or unanswerable from the text
 - Do not change IDs on rows that are only lightly edited
 


### PR DESCRIPTION
Strengthens guidance for Translation Questions authoring and updates to ensure consistency, prevent scope creep, and maintain question quality.

Key changes:

- **Question framing**: Added explicit preference for "what/who/where/when/how" over "why" questions. New "why" questions are discouraged as they tend toward interpretation rather than comprehension checks, though existing well-functioning "why" questions are preserved. Provided reframing guidance (e.g., "What does Yahweh say he will do because of their sins?" instead of "Why will Yahweh punish them?").

- **Update discipline**: Clarified that TQ updates are incremental refinements of existing sets, not fresh authoring passes. Each existing row produces exactly one updated row; the chapter's row count and verse References remain stable unless content genuinely relocated. Prohibited re-sequencing or compressing References to fit a new question order.

- **In-place editing**: Emphasized editing question wording to reflect ULT/UST changes while preserving subject and scope. Replacing a question with a different one on the same row is not an update—it discards a vetted comprehension check.

- **Row stability**: Reinforced that one row in produces one row out. Splitting or folding questions is not permitted. Adding questions is a rare exception only when a verse changed so drastically its existing row has no answerable content.

- **Fail-safe handling**: Added guidance for matching gaps: if an existing TQ row cannot be confidently aligned to a verse in the prepared data, keep it unchanged rather than regenerating the chapter from scratch. Wholesale regeneration inflates question count, introduces off-type questions, and re-anchors references incorrectly.

- **Terminology and style**: Clarified what to update (terminology, structure, clarity) versus what not to change (well-functioning questions, question count, IDs on lightly edited rows).

These changes codify constraints that prevent common failure modes: question proliferation, scope drift, and loss of vetted comprehension checks during updates.

https://claude.ai/code/session_01Uoj8zEA3WKn2AgWba5ELpx