### PR TITLE
ci(review-gate): bump actions/github-script v7 to v8

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -248,7 +248,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           SUMMARY: ${{ steps.review.outputs.summary }}
           DECISION: ${{ steps.review.outputs.decision }}


### PR DESCRIPTION
Bumps `actions/github-script` from `@v7` to `@v8` in `.github/workflows/review-gate.yml` (line 251, the only `@v7` usage in the repo).

Fixes the GitHub Actions Node.js 20 deprecation warning — v8 targets Node 24 natively. No script-API changes between v7 and v8, so the inline `script:` block is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)