### PR TITLE
fix(alignment): MCP-only alignment, no improvised scripts, resumable batches

### DIFF
--- a/.claude/skills/ULT-alignment/SKILL.md
+++ b/.claude/skills/ULT-alignment/SKILL.md
@@ -3,14 +3,29 @@ name: ULT-alignment
 
 description: Create word-level alignments between Hebrew source and English ULT text. AI produces index-based mapping JSON that a script converts to aligned USFM. Use when asked to align ULT or produce aligned ULT USFM.
 
-allowed-tools: Read, Grep, Glob, Bash
+allowed-tools: Read, Grep, Glob, Write, mcp__workspace-tools__create_aligned_usfm, mcp__workspace-tools__merge_aligned_usfm, mcp__workspace-tools__validate_alignment_json, mcp__workspace-tools__validate_alignment_integrity, mcp__workspace-tools__extract_ult_english, mcp__workspace-tools__check_ult_voice_mismatch, mcp__workspace-tools__curly_quotes
 ---
 
 ## Overview
 
 This skill maps English ULT words to Hebrew source words. The workflow is two-step:
 1. **AI creates** a simple index-based mapping (English words to Hebrew word positions)
-2. **Script converts** that mapping to properly formatted aligned USFM
+2. **The `create_aligned_usfm` MCP tool converts** that mapping to properly formatted aligned USFM
+
+## No shell — use MCP tools, never write or run scripts
+
+This skill runs **without Bash** — there is no shell. Every `bash`/`node`/`grep`/
+`sed`/`diff`/`cat` example below is illustrative only; perform the equivalent with
+the `Read`/`Grep`/`Write` tools and the `mcp__workspace-tools__*` tools.
+
+- **NEVER** write a Node/Python/shell script (e.g. `generate_*.js`) to produce or
+  combine aligned USFM, and never try to run one — it cannot be executed. This is
+  the single most common way this skill fails; do not do it.
+- Convert each verse with `mcp__workspace-tools__create_aligned_usfm` (pass
+  `output` so it writes a per-verse file). Assemble a multi-verse range with
+  `mcp__workspace-tools__merge_aligned_usfm` — see "Combining Multiple Verses".
+- If a tool returns an error, fix the mapping JSON and call it again, or report
+  the failure. Never fall back to hand-writing or scripting the USFM.
 
 ## Input Requirements
 
@@ -342,28 +357,26 @@ Both comparisons should show no differences. If there are differences, the align
 
 ## Conversion to Aligned USFM
 
-After creating the mapping JSON, convert it to aligned USFM using the conversion tool. This step is mandatory -- never write aligned USFM directly, as manual occurrence counting is error-prone.
+After creating the mapping JSON, convert it to aligned USFM with the
+`create_aligned_usfm` MCP tool. This step is mandatory -- never write aligned
+USFM directly (manual occurrence counting is error-prone) and never script it.
 
-**Option A — MCP tool (preferred, works without Bash):**
 ```
 mcp__workspace-tools__create_aligned_usfm({
   hebrew: "data/hebrew_bible/01-GEN.usfm",
   mapping: "tmp/alignments/GEN-01-001.json",
   source: "output/AI-ULT/GEN/GEN-01.usfm",
+  output: "tmp/aligned/GEN-01-001-aligned.usfm",
   chapter: 1, verse: 1
 })
 ```
 
-**Option B — Bash (when available):**
-```bash
-node .claude/skills/utilities/scripts/usfm/create_aligned_usfm.js \
-  --hebrew data/hebrew_bible/01-GEN.usfm \
-  --mapping /tmp/alignments/GEN-01-01.json \
-  --ult output/AI-ULT/GEN/GEN-01.usfm \
-  --chapter 1 --verse 1
-```
+Pass `output` to write a per-verse aligned file (also runs the x-content byte
+repair automatically); omit `output` to get the aligned USFM back as text. Use
+the `output` form so you can assemble the verses with `merge_aligned_usfm`
+(see "Combining Multiple Verses") — no shell needed.
 
-The script:
+The tool:
 1. Reads Hebrew USFM to get full word metadata (Strong's, lemma, morph, x-content)
 2. Reads your mapping JSON
 3. Parses `english_text` to determine correct word order
@@ -390,36 +403,38 @@ After converting all verses, save the combined aligned USFM to `output/AI-ULT/{B
 
 ### Combining Multiple Verses
 
-The script outputs **multi-line USFM** (one line per word/alignment). When combining verses:
+To produce a multi-verse file (a whole chapter, or a `--verses START-END` batch),
+do it entirely with MCP tools — **no shell, no script, no manual concatenation**:
 
-```bash
-# Create header
-cat > output/AI-ULT/PSA/PSA-078-44-72-aligned.usfm << 'EOF'
-\id PSA EN_ULT - Aligned
-\usfm 3.0
-\ide UTF-8
-\h Psalms
-\mt Psalms
+1. Convert each verse to its **own** per-verse file with `create_aligned_usfm`,
+   passing `output`:
+   ```
+   mcp__workspace-tools__create_aligned_usfm({
+     hebrew: "data/hebrew_bible/19-PSA.usfm",
+     mapping: "tmp/alignments/PSA-078-044.json",
+     source: "output/AI-ULT/PSA/PSA-078.usfm",
+     output: "tmp/aligned/PSA-078-044-aligned.usfm",
+     chapter: 78, verse: 44
+   })
+   ```
+   Repeat for every verse in the range (zero-pad mapping filenames, e.g.
+   `PSA-078-044.json`). Inter-verse markers (`\qa`, `\s1`, `\b`) and aligned `\d`
+   lines are emitted automatically per verse.
 
-\c 78
-EOF
-
-# Append each verse (--ult preserves poetry markers, inter-verse markers, and \d lines)
-for v in $(seq 44 72); do
-  vpad=$(printf "%03d" $v)
-  node .claude/skills/utilities/scripts/usfm/create_aligned_usfm.js \
-    --hebrew data/hebrew_bible/19-PSA.usfm \
-    --mapping alignments/PSA-078-${vpad}.json \
-    --ult output/AI-ULT/PSA/PSA-078-44-72.usfm \
-    --chapter 78 --verse $v 2>/dev/null | sed -n '/^\\[vqdsb]/,/^$/p' >> output/AI-ULT/PSA/PSA-078-44-72-aligned.usfm
-done
-```
+2. Assemble the per-verse files **in verse order** with `merge_aligned_usfm`:
+   ```
+   mcp__workspace-tools__merge_aligned_usfm({
+     parts: ["tmp/aligned/PSA-078-044-aligned.usfm", "tmp/aligned/PSA-078-045-aligned.usfm", ...],
+     output: "output/AI-ULT/PSA/PSA-078-v44-v72-aligned.usfm"
+   })
+   ```
+   `merge_aligned_usfm` keeps the first part's header and appends each subsequent
+   part's verse body — so the assembled file has one header and all verses in
+   order. This replaces the old `cat`/`node`/`sed` loop.
 
 **Notes:**
-- Use `sed -n '/^\\[vqdsb]/,/^$/p'` to capture verse line, inter-verse markers (`\qa`, `\d`, `\s1`, `\b`), and all alignment lines until blank (do NOT use `[vqdstb]` — the `t` matches `\toc` headers)
-- Do NOT use `grep "^\v"` - this only gets the first line and truncates alignments
-- Use zero-padded verse numbers in mapping filenames (e.g., `PSA-078-044.json`)
-- Inter-verse markers (`\qa`, `\s1`, `\b`, etc.) and aligned `\d` lines are inserted automatically by the script -- no manual insertion needed
+- Parts MUST be listed in ascending verse order — merge preserves the given order.
+- Never hand-write the header or `cat` verses together; let `merge_aligned_usfm` do it.
 
 ### Naming Convention
 
@@ -521,7 +536,7 @@ grep -oE '\\w [^|]+\|' aligned.usfm | sed 's/\\w //;s/|//' | tr '\n' ' '
 
 After text verification passes, check that the milestone fields are faithful to the Hebrew source. This catches the Unicode byte-form drift behind issues #88-#91: an x-content or x-lemma that looks identical to the Hebrew but differs in bytes, plus empty fields, occurrence-numbering errors, and unaligned Hebrew words.
 
-Option A — MCP tool (preferred, works without Bash):
+Use the `validate_alignment_integrity` MCP tool:
 ```
 mcp__workspace-tools__validate_alignment_integrity({
   aligned: "output/AI-ULT/{BOOK}/{BOOK}-{CHAPTER}-aligned.usfm",
@@ -530,15 +545,7 @@ mcp__workspace-tools__validate_alignment_integrity({
 })
 ```
 
-Option B — Bash (when available):
-```bash
-node .claude/skills/utilities/scripts/validation/validate_alignment_integrity.mjs \
-  --aligned output/AI-ULT/{BOOK}/{BOOK}-{CHAPTER}-aligned.usfm \
-  --hebrew data/hebrew_bible/{NN}-{BOOK}.usfm \
-  --chapter {CHAPTER}
-```
-
-Exit code 0 = clean; 1 = problems listed per verse. Fix the mapping JSON (usually by re-copying the Hebrew word byte-for-byte from the source) and re-convert before continuing. Do not hand-edit the aligned USFM to silence a finding.
+Its first line starts `OK:` (clean) or `FAIL:` (problems listed per verse). Fix the mapping JSON (usually by re-copying the Hebrew word byte-for-byte from the source) and re-convert before continuing. Do not hand-edit the aligned USFM to silence a finding.
 
 ## Step 8: Check for Voice Mismatches
 

--- a/.claude/skills/UST-alignment/SKILL.md
+++ b/.claude/skills/UST-alignment/SKILL.md
@@ -3,16 +3,31 @@ name: UST-alignment
 
 description: Create meaning-based alignments between Hebrew source and English UST text. Handles radical restructuring and implied information. Use when asked to align UST or produce aligned UST USFM.
 
-allowed-tools: Read, Grep, Glob, Bash
+allowed-tools: Read, Grep, Glob, Write, mcp__workspace-tools__create_aligned_usfm, mcp__workspace-tools__merge_aligned_usfm, mcp__workspace-tools__validate_alignment_json, mcp__workspace-tools__validate_alignment_integrity, mcp__workspace-tools__curly_quotes
 ---
 
 ## Overview
 
 This skill maps English UST phrases to Hebrew source words. The workflow is two-step:
 1. **AI creates** an index-based mapping (English phrases to Hebrew word positions)
-2. **Script converts** that mapping to properly formatted aligned USFM
+2. **The `create_aligned_usfm` MCP tool converts** that mapping to properly formatted aligned USFM
 
 UST alignment is fundamentally different from ULT alignment. Where ULT aims for word-level precision, UST shows which Hebrew word(s) contribute meaning to each English phrase. The mapping is concept-to-phrase, not word-to-word.
+
+## No shell — use MCP tools, never write or run scripts
+
+This skill runs **without Bash** — there is no shell. Every `bash`/`node`/`grep`/
+`sed`/`cat` example below is illustrative only; perform the equivalent with the
+`Read`/`Grep`/`Write` tools and the `mcp__workspace-tools__*` tools.
+
+- **NEVER** write a Node/Python/shell script (e.g. `generate_*.js`) to produce or
+  combine aligned USFM, and never try to run one — it cannot be executed. This is
+  the single most common way this skill fails.
+- Convert each verse with `mcp__workspace-tools__create_aligned_usfm` (`ust: true`,
+  pass `output`), then assemble a range with `mcp__workspace-tools__merge_aligned_usfm`
+  — see "Combining Multiple Verses".
+- If a tool returns an error, fix the mapping JSON and call it again, or report the
+  failure. Never fall back to hand-writing or scripting the USFM.
 
 ## Input Requirements
 
@@ -292,28 +307,21 @@ After creating the mapping JSON, convert it to aligned USFM using the conversion
 
 > **Critical:** `source` MUST point to the **UST file** (`output/AI-UST/BOOK/...`). Never pass the ULT file here. If you pass the ULT file, the output will silently contain ULT English text and look structurally valid -- the error will not be obvious.
 
-**Option A -- MCP tool (preferred, works without Bash):**
+Use the `create_aligned_usfm` MCP tool with `ust: true`. Pass `output` to write a
+per-verse file (so you can assemble a range with `merge_aligned_usfm`); omit it to
+get the aligned USFM back as text.
 ```
 mcp__workspace-tools__create_aligned_usfm({
   hebrew: "data/hebrew_bible/19-PSA.usfm",
   mapping: "tmp/alignments/PSA-001-001.json",
   source: "output/AI-UST/PSA/PSA-001.usfm",
+  output: "tmp/aligned/PSA-001-001-aligned.usfm",
   ust: true,
   chapter: 1, verse: 1
 })
 ```
 
-**Option B -- Bash (when available):**
-```bash
-node .claude/skills/utilities/scripts/usfm/create_aligned_usfm.js \
-  --hebrew data/hebrew_bible/19-PSA.usfm \
-  --mapping /tmp/alignments/PSA-001-001.json \
-  --source output/AI-UST/PSA/PSA-001.usfm \
-  --ust \
-  --chapter 1 --verse 1
-```
-
-The `--ust` flag tells the script to:
+The `ust: true` flag tells the tool to:
 - Place brackets outside milestones (not inside `\w` tags)
 - Wrap contiguous bracket groups as a unit
 - Use `EN_UST` in the header id tag
@@ -335,29 +343,31 @@ vs ULT mode where brackets go inside `\w` tags:
 
 ### Combining Multiple Verses
 
-```bash
-# Create header
-cat > output/AI-UST/PSA/PSA-001-aligned.usfm << 'EOF'
-\id PSA EN_UST - Aligned
-\usfm 3.0
-\ide UTF-8
-\h Psalms
-\mt Psalms
+Do it entirely with MCP tools — **no shell, no script, no manual concatenation**:
 
-\c 1
-EOF
+1. Convert each verse to its **own** per-verse file with `create_aligned_usfm`
+   (`ust: true`, passing `output`):
+   ```
+   mcp__workspace-tools__create_aligned_usfm({
+     hebrew: "data/hebrew_bible/19-PSA.usfm",
+     mapping: "tmp/alignments/PSA-001-001.json",
+     source: "output/AI-UST/PSA/PSA-001.usfm",
+     output: "tmp/aligned/PSA-001-001-aligned.usfm",
+     ust: true, chapter: 1, verse: 1
+   })
+   ```
+   Repeat for every verse in the range (zero-pad mapping filenames).
 
-# Append each verse
-for v in $(seq 1 6); do
-  vpad=$(printf "%03d" $v)
-  node .claude/skills/utilities/scripts/usfm/create_aligned_usfm.js \
-    --hebrew data/hebrew_bible/19-PSA.usfm \
-    --mapping alignments/PSA-001-${vpad}.json \
-    --source output/AI-UST/PSA/PSA-001.usfm \
-    --ust \
-    --chapter 1 --verse $v 2>/dev/null | sed -n '/^\\[vqdsb]/,/^$/p' >> output/AI-UST/PSA/PSA-001-aligned.usfm
-done
-```
+2. Assemble the per-verse files **in verse order** with `merge_aligned_usfm`:
+   ```
+   mcp__workspace-tools__merge_aligned_usfm({
+     parts: ["tmp/aligned/PSA-001-001-aligned.usfm", "tmp/aligned/PSA-001-002-aligned.usfm", ...],
+     output: "output/AI-UST/PSA/PSA-001-aligned.usfm"
+   })
+   ```
+   It keeps the first part's header and appends each subsequent part's verse body.
+   This replaces the old `cat`/`node`/`sed` loop — never hand-write the header or
+   concatenate verses yourself.
 
 ### Naming Convention
 
@@ -415,7 +425,7 @@ grep -oE '\\w [^|]+\|' aligned.usfm | sed 's/\\w //;s/|//' | tr '\n' ' '
 
 Check that milestone fields are faithful to the Hebrew source (byte-exact x-content/x-lemma, occurrence numbering). UST mode allows unaligned Hebrew words, which are normal for UST.
 
-Option A — MCP tool (preferred, works without Bash):
+Use the `validate_alignment_integrity` MCP tool:
 ```
 mcp__workspace-tools__validate_alignment_integrity({
   aligned: "output/AI-UST/{BOOK}/{BOOK}-{CHAPTER}-aligned.usfm",
@@ -424,15 +434,7 @@ mcp__workspace-tools__validate_alignment_integrity({
 })
 ```
 
-Option B — Bash (when available):
-```bash
-node .claude/skills/utilities/scripts/validation/validate_alignment_integrity.mjs \
-  --aligned output/AI-UST/{BOOK}/{BOOK}-{CHAPTER}-aligned.usfm \
-  --hebrew data/hebrew_bible/{NN}-{BOOK}.usfm \
-  --chapter {CHAPTER} --ust
-```
-
-Exit code 0 = clean; 1 = problems listed per verse. Fix the mapping JSON and re-convert rather than hand-editing the aligned USFM.
+Its first line starts `OK:` (clean) or `FAIL:` (problems listed per verse). Fix the mapping JSON and re-convert rather than hand-editing the aligned USFM.
 
 ## Quality Checklist
 

--- a/.claude/skills/align-all-parallel/SKILL.md
+++ b/.claude/skills/align-all-parallel/SKILL.md
@@ -10,6 +10,21 @@ allowed-tools: Task, Read, mcp__workspace-tools__read_usfm_chapter, mcp__workspa
 
 Spawn alignment agents in parallel and wait for them to complete.
 
+## No shell — never write or run scripts
+
+This skill and its subagents run **without Bash** — there is no shell to execute
+anything. Do every step with the `Task` tool (to spawn alignment subagents),
+`Read`, and the `mcp__workspace-tools__*` tools.
+
+- **NEVER** write a Node/Python/shell script (e.g. `generate_*.js`) to produce or
+  combine aligned USFM, and never try to run one — it cannot be executed and only
+  wastes the run.
+- Per-verse conversion is done inside the subagents via
+  `mcp__workspace-tools__create_aligned_usfm`; the full-chapter assembly is done
+  here via `mcp__workspace-tools__merge_aligned_usfm` (Step 2e).
+- If a batch subagent fails or a tool returns an error, **re-spawn that batch or
+  report the failure plainly** — do not improvise a script to work around it.
+
 ## Pipeline Context
 
 If `--context <path>` is provided, read the context.json file. It contains the authoritative source paths:
@@ -64,12 +79,22 @@ Examples:
 
 ## Step 2c: Spawn ALL Batches in Parallel
 
-Launch all batch subagents in a **single message** — do not wait between batches:
+**First, skip batches that are already done (resume support).** For each batch,
+`Read` its expected partial output (`output/AI-{ULT,UST}/BOOK/BOOK-CH-vSTART-vEND-aligned.usfm`).
+If the file already exists and contains every verse in that batch's range (each
+`\v` present, with `\zaln-s` alignment markers), that batch is complete — do NOT
+re-spawn it. Only spawn subagents for the batches still missing or incomplete.
+This lets a resumed run finish a long chapter by filling just the remaining
+batches instead of re-aligning everything (and timing out again).
 
-- For each batch K (1..numBatches):
+Launch the still-needed batch subagents in a **single message** — do not wait between batches:
+
+- For each batch K (1..numBatches) that is NOT already complete:
   - If running ULT: spawn `ult-align-K` subagent (`model: "sonnet"`, skill: ULT-alignment) for `BOOK CH --verses START-END`
   - If running UST: spawn `ust-align-K` subagent (`model: "sonnet"`, skill: UST-alignment) for `BOOK CH --verses START-END`
-- All subagents launch at once (e.g., 4 batches × 2 types = 8 parallel subagents)
+- All still-needed subagents launch at once (e.g., 4 batches × 2 types = 8 parallel subagents)
+
+If every batch is already complete, skip straight to Step 2d/2e (consistency check + merge).
 
 **Parallel cap:** If the chapter has more than 5 batches per type (>90 verses), split into waves of 5 batches each. Run wave 1 (batches 1–5), wait for completion, then run wave 2 (batches 6–N). This keeps total parallel agents manageable.
 


### PR DESCRIPTION
## Why
Long chapters (e.g. JER 32) repeatedly failed alignment. The align subagents run without Bash, but the alignment skills still documented a Bash-only conversion/assembly path, so a subagent improvised an unrunnable Node script (`generate_jer32_v31_v44_ust.js`) and produced nothing.

## What
- **ULT-alignment / UST-alignment**: remove the Bash options; document the MCP-only path (`create_aligned_usfm` per verse with `output`, then `merge_aligned_usfm` to assemble). Add a "No shell — never write or run scripts" guardrail. Fix `allowed-tools` (Bash → Write + the workspace-tools MCP tools used).
- **align-all-parallel**: same no-scripts guardrail; make Step 2c resumable — skip already-complete batches so a resumed long chapter fills only the remaining batches.

Pairs with the `bp-assistant` pipeline PR that banks source-consistent batches across runs and adds a full-chapter coverage gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)