### PR TITLE
fix(review-gate): post a new PR comment per run instead of upserting

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -252,26 +252,25 @@ jobs:
         env:
           SUMMARY: ${{ steps.review.outputs.summary }}
           DECISION: ${{ steps.review.outputs.decision }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           script: |
+            // One new comment per run (not an upsert of a single sticky comment) so
+            // rapid-fire pushes each leave a visible, timestamped verdict in the PR
+            // timeline instead of silently overwriting the previous run's comment.
             const marker = '<!-- bp-review-gate -->';
             const body = [
               marker,
               '## Remote Review Gate',
               '',
               `- Decision: ${process.env.DECISION}`,
+              `- Commit: ${process.env.HEAD_SHA}`,
               '',
               process.env.SUMMARY,
             ].join('\n');
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
-            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 });
-            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
 
       - name: Enforce Gate
         env:


### PR DESCRIPTION
## Summary
- The `Comment PR` step in `review-gate.yml` looked for an existing comment tagged with a hidden `<!-- bp-review-gate -->` marker and updated it in place on every run.
- On PRs with several pushes in quick succession, each new run's verdict silently overwrote the previous one in the same comment, with no new entry appearing in the PR timeline. This made it look like some review runs never posted feedback, when in fact they had edited the existing comment.
- Now every run always creates a new comment, and the comment includes the reviewed commit SHA so each one is distinguishable.

## Test plan
- [ ] Push two commits to a PR in quick succession and confirm two separate `Remote Review Gate` comments appear (not one comment being edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)