### PR TITLE
fix: make tn-quality-check report write unconditional (closes #115)

### DIFF
--- a/.claude/skills/tn-quality-check/SKILL.md
+++ b/.claude/skills/tn-quality-check/SKILL.md
@@ -50,6 +50,8 @@ If neither exists, report an error and exit.
 
 ## Workflow
 
+**Required final output:** Every run of this skill MUST end by (over)writing `output/quality/<BOOK>/<BOOK>-<CH>-quality.md` in Step 5. The pipeline checks that file's mtime against chapter start and fails the chapter as `stale_output` if it was not written in the current run. This holds even when there are no issues to fix, when Step 4 exits early, or when a report already exists from a prior run.
+
 ### Step 0: Fix Trailing Newlines
 
 Use `mcp__workspace-tools__fix_trailing_newlines` with `file: <NOTES_TSV>`.
@@ -178,11 +180,13 @@ After any changes to the generated-notes JSON or prepared-notes JSON, re-run ass
 
 Re-assemble with `mcp__workspace-tools__assemble_notes`, then run `mcp__workspace-tools__curly_quotes` (`inPlace: true`).
 
-After fixing, you may re-run `check_tn_quality` **at most once** to verify the fixes landed. If issues persist after that one re-check, add them to the quality report as "unresolved — needs manual review" and stop. Do not run a third check cycle.
+After fixing, you may re-run `check_tn_quality` **at most once** to verify the fixes landed. If issues persist after that one re-check, add them to the quality report as "unresolved — needs manual review" and continue to Step 5. Do not run a third check cycle. "Stop" here means stop the re-check loop, not the skill — Step 5 still runs.
 
-### Step 5: Write Report
+### Step 5: Write Report (mandatory — do not skip)
 
-Write the final quality report to `output/quality/<BOOK>/<BOOK>-<CH>-quality.md`:
+**This step is unconditional.** Every invocation of tn-quality-check MUST end by writing (overwriting) the report file below in the current run. Skipping Step 5 — because "nothing needed fixing," because you already wrote it earlier in the run, because you thought you were done after Step 4, or because a report already exists on disk — causes the pipeline's post-run freshness check to raise `stale_output` and fail the chapter (see issue #115). A pre-existing file at this path from a prior run is **not** proof that this step ran; the pipeline compares the file's mtime against chapter start.
+
+Write the final quality report to `output/quality/<BOOK>/<BOOK>-<CH>-quality.md` as the final action of this skill (after any fixes, re-checks, or early exits):
 
 ```markdown
 # TN Quality Report: <BOOK> <CHAPTER>


### PR DESCRIPTION
Closes #115.

## Summary

The tn-quality-check skill failed on NAM 1 with `errorKind: stale_output` — the pipeline's post-run freshness check found `output/quality/NAM/NAM-01-quality.md` predated chapter start. The skill agent finished after ~10 minutes (well under the 105 min timeout) without (over)writing the required report.

Two failure paths in the previous SKILL.md let the agent think it was done before Step 5:

1. Step 4's re-check guardrail ended with "add them to the quality report as 'unresolved — needs manual review' and stop." "Stop" was meant as "stop the re-check loop," but reads to an agent as "stop the whole skill."
2. Step 5 was the last section but not framed as mandatory; nothing pushed back on "no issues found → skip writing the report."

## Change

`.claude/skills/tn-quality-check/SKILL.md`:

- Add a Workflow preamble stating that every run MUST end by (over)writing the report file in the current run, referencing this issue and explaining the freshness check.
- Reword Step 4's "stop" to make explicit it means "stop the re-check loop, not the skill — Step 5 still runs."
- Retitle Step 5 "Write Report (mandatory — do not skip)" and add a paragraph enumerating the ways an agent might wrongly skip it (no issues, already wrote earlier, pre-existing file on disk, early exit from Step 4).

This mirrors the pattern used in #119 for align-all-parallel: fail loudly on stale outputs and instruct the coordinator to guarantee freshness rather than trust the presence of a file.

## Verification

- Reviewed the align-all-parallel fix (462185a) for the analogous pattern and matched the tone/structure.
- No code changes; SKILL.md-only edit. Next NAM 1 run will exercise the new wording.