### PR TITLE
align: distinct -ult/-ust tokens for mapping JSON to prevent collisions

### DIFF
--- a/.claude/skills/ULT-alignment/SKILL.md
+++ b/.claude/skills/ULT-alignment/SKILL.md
@@ -318,11 +318,19 @@ This checks that every Hebrew index is aligned, every English word appears exact
 
 ### Step 6: Save JSON
 
-Write to scratchpad or output directory:
+Write mapping JSON to `tmp/alignments/` using this exact naming:
 
 ```
-/tmp/claude-*/scratchpad/alignments/GEN-01-01.json
+tmp/alignments/{BOOK}-{CH}-{VVV}-ult.json      # e.g. tmp/alignments/GEN-01-001-ult.json
 ```
+
+**Naming rules (must match UST-alignment for consistency):**
+- **Type token** — always end the basename with `-ult` (UST uses `-ust`). ULT and UST
+  subagents run in parallel and share `tmp/alignments/` and `tmp/aligned/`; without a
+  distinct type token they silently overwrite each other's intermediates. Do NOT rely on
+  padding differences to avoid collisions — always use the token.
+- **Chapter** — zero-pad to 2 digits (`05`); books with ≥100 chapters (Psalms) use 3 (`078`).
+- **Verse** — zero-pad to 3 digits (`001`).
 
 ### Step 7: Verify Text Preservation
 
@@ -364,9 +372,9 @@ USFM directly (manual occurrence counting is error-prone) and never script it.
 ```
 mcp__workspace-tools__create_aligned_usfm({
   hebrew: "data/hebrew_bible/01-GEN.usfm",
-  mapping: "tmp/alignments/GEN-01-001.json",
+  mapping: "tmp/alignments/GEN-01-001-ult.json",
   source: "output/AI-ULT/GEN/GEN-01.usfm",
-  output: "tmp/aligned/GEN-01-001-aligned.usfm",
+  output: "tmp/aligned/GEN-01-001-ult-aligned.usfm",
   chapter: 1, verse: 1
 })
 ```
@@ -411,20 +419,20 @@ do it entirely with MCP tools — **no shell, no script, no manual concatenation
    ```
    mcp__workspace-tools__create_aligned_usfm({
      hebrew: "data/hebrew_bible/19-PSA.usfm",
-     mapping: "tmp/alignments/PSA-078-044.json",
+     mapping: "tmp/alignments/PSA-078-044-ult.json",
      source: "output/AI-ULT/PSA/PSA-078.usfm",
-     output: "tmp/aligned/PSA-078-044-aligned.usfm",
+     output: "tmp/aligned/PSA-078-044-ult-aligned.usfm",
      chapter: 78, verse: 44
    })
    ```
-   Repeat for every verse in the range (zero-pad mapping filenames, e.g.
-   `PSA-078-044.json`). Inter-verse markers (`\qa`, `\s1`, `\b`) and aligned `\d`
+   Repeat for every verse in the range (zero-pad mapping filenames and keep the
+   `-ult` token, e.g. `PSA-078-044-ult.json`). Inter-verse markers (`\qa`, `\s1`, `\b`) and aligned `\d`
    lines are emitted automatically per verse.
 
 2. Assemble the per-verse files **in verse order** with `merge_aligned_usfm`:
    ```
    mcp__workspace-tools__merge_aligned_usfm({
-     parts: ["tmp/aligned/PSA-078-044-aligned.usfm", "tmp/aligned/PSA-078-045-aligned.usfm", ...],
+     parts: ["tmp/aligned/PSA-078-044-ult-aligned.usfm", "tmp/aligned/PSA-078-045-ult-aligned.usfm", ...],
      output: "output/AI-ULT/PSA/PSA-078-v44-v72-aligned.usfm"
    })
    ```

--- a/.claude/skills/UST-alignment/SKILL.md
+++ b/.claude/skills/UST-alignment/SKILL.md
@@ -296,10 +296,18 @@ Use `mcp__workspace-tools__validate_alignment_json` with `files` set to the arra
 
 ### Step 9: Save JSON
 
-Write to scratchpad or output directory:
+Write mapping JSON to `tmp/alignments/` using this exact naming:
 ```
-/tmp/claude-*/scratchpad/alignments/PSA-001-001.json
+tmp/alignments/{BOOK}-{CH}-{VVV}-ust.json      # e.g. tmp/alignments/PSA-001-001-ust.json
 ```
+
+**Naming rules (must match ULT-alignment for consistency):**
+- **Type token** — always end the basename with `-ust` (ULT uses `-ult`). ULT and UST
+  subagents run in parallel and share `tmp/alignments/` and `tmp/aligned/`; without a
+  distinct type token they silently overwrite each other's intermediates. Do NOT rely on
+  padding differences to avoid collisions — always use the token.
+- **Chapter** — zero-pad to 2 digits (`05`); books with ≥100 chapters (Psalms) use 3 (`001`).
+- **Verse** — zero-pad to 3 digits (`001`).
 
 ## Conversion to Aligned USFM
 
@@ -313,9 +321,9 @@ get the aligned USFM back as text.
 ```
 mcp__workspace-tools__create_aligned_usfm({
   hebrew: "data/hebrew_bible/19-PSA.usfm",
-  mapping: "tmp/alignments/PSA-001-001.json",
+  mapping: "tmp/alignments/PSA-001-001-ust.json",
   source: "output/AI-UST/PSA/PSA-001.usfm",
-  output: "tmp/aligned/PSA-001-001-aligned.usfm",
+  output: "tmp/aligned/PSA-001-001-ust-aligned.usfm",
   ust: true,
   chapter: 1, verse: 1
 })
@@ -350,18 +358,18 @@ Do it entirely with MCP tools — **no shell, no script, no manual concatenation
    ```
    mcp__workspace-tools__create_aligned_usfm({
      hebrew: "data/hebrew_bible/19-PSA.usfm",
-     mapping: "tmp/alignments/PSA-001-001.json",
+     mapping: "tmp/alignments/PSA-001-001-ust.json",
      source: "output/AI-UST/PSA/PSA-001.usfm",
-     output: "tmp/aligned/PSA-001-001-aligned.usfm",
+     output: "tmp/aligned/PSA-001-001-ust-aligned.usfm",
      ust: true, chapter: 1, verse: 1
    })
    ```
-   Repeat for every verse in the range (zero-pad mapping filenames).
+   Repeat for every verse in the range (zero-pad mapping filenames and keep the `-ust` token).
 
 2. Assemble the per-verse files **in verse order** with `merge_aligned_usfm`:
    ```
    mcp__workspace-tools__merge_aligned_usfm({
-     parts: ["tmp/aligned/PSA-001-001-aligned.usfm", "tmp/aligned/PSA-001-002-aligned.usfm", ...],
+     parts: ["tmp/aligned/PSA-001-001-ust-aligned.usfm", "tmp/aligned/PSA-001-002-ust-aligned.usfm", ...],
      output: "output/AI-UST/PSA/PSA-001-aligned.usfm"
    })
    ```


### PR DESCRIPTION
## Problem
ULT- and UST-alignment subagents run in parallel and share `tmp/alignments/` and `tmp/aligned/`. With identical basenames they silently overwrite each other's intermediate JSON/USFM. The only thing preventing that today is an accidental padding divergence (ULT `AMO-05-NNN`, UST `AMO-005-NNN`) — which itself breaks any consumer that assumes one naming scheme (this contributed to the AMO 5 missing_output failure and the salvage disambiguation complexity in bp-assistant).

## Fix
Require an explicit `-ult` / `-ust` **type token** on all intermediate mapping JSON and per-verse aligned USFM in both skills, and standardize padding (chapter 2-digit, Psalms 3; verse 3-digit). Final output USFM naming is unchanged (already separated by `AI-ULT/` vs `AI-UST/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011H2SHc5ChcpRrvCx1tHhAP
